### PR TITLE
update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ git clone https://github.com/Dexmal/dexbotic.git
 2. Step 2: Start Docker
 
 ```bash
-docker run -it --rm --gpus all \
+docker run -it --rm --gpus all --network host \
   -v /path/to/dexbotic:/dexbotic \
   dexmal/dexbotic \
   bash


### PR DESCRIPTION
Add `--network host` to the Docker start command so the container shares the host network, allowing `dexbotic-benchmark` to access the model server running on the host.
