### PR TITLE
Replace build backend with hatchling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ attention = [
     "xformers"
 ]
 
-[tool.setuptools]
+[tool.hatch.build.targets.wheel]
 packages = ["dexbotic"]
 
 [tool.autopep8]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["setuptools>=61.0"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
 [project]
 name = "dexbotic"


### PR DESCRIPTION
## 📝 PR Description

### Purpose
setuptools fail to install package correctly. [hatch](https://hatch.pypa.io/dev/intro/), widely used modern, extensible Python project manager does not have error.

Rationale of PR: I did tried to use code from dexbotic but fail with setuptools :(

```sh
$ uv pip install "git+https://github.com/Dexmal/dexbotic.git@0.2.0"
Resolved 183 packages in 582ms
Uninstalled 2 packages in 208ms
Installed 2 packages in 138ms
 ~ decord==0.6.0
 - dexbotic==0.2.0 (from git+https://github.com/MilkClouds/dexbotic.git@42f72859dfe48bb4c30a09ab151a018c2ca0700a)
 + dexbotic==0.2.0 (from git+https://github.com/Dexmal/dexbotic.git@932192c796c030babf4f10e3dcd6da27d093fc05)
$ python -c "import dexbotic.model"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ModuleNotFoundError: No module named 'dexbotic.model'

$ uv pip install "git+https://github.com/MilkClouds/dexbotic.git@build-with-hatch"
Resolved 183 packages in 648ms
Uninstalled 2 packages in 78ms
Installed 2 packages in 191ms
 ~ decord==0.6.0
 - dexbotic==0.2.0 (from git+https://github.com/Dexmal/dexbotic.git@932192c796c030babf4f10e3dcd6da27d093fc05)
 + dexbotic==0.2.0 (from git+https://github.com/MilkClouds/dexbotic.git@42f72859dfe48bb4c30a09ab151a018c2ca0700a)
$ python -c "import dexbotic.model" # do not fail
$ 
```

### Change Summary
Replaced setuptools to hatch

### Benchmark Evidence
Already stated on above.

### Reproduce Command
Already stated on above.

### Dependencies
None

### Environment
N/A
 
## ✔️ Review Checklist (must all be checked)
- [x] No breaking changes to core interfaces (VLA API / Dexdata)
- [x] No redundant implementation (checked existing modules first)
- [x] Code follows existing design [link](https://dexbotic.com/docs/3.%20Architecture.html#overall-framework-diagram)
- [x] Local validation completed with commands + expected output
- [x] Benchmark evaluation completed and attached
- [x] No regressions observed
- [x] No new dependencies or all new dependencies listed
- [x] Merges cleanly on current main and builds successfully
