### PR TITLE
fix: replace 8 bare excepts with except Exception across 4 files

### DIFF
--- a/dexbotic/exp/navila_exp.py
+++ b/dexbotic/exp/navila_exp.py
@@ -392,7 +392,7 @@ class NaVILAInferenceConfig(InferenceConfig):
 
         try:
             actions = [map_string_to_action(outputs)]
-        except:
+        except Exception:
             actions = [1]
 
         queue_actions = []
@@ -401,7 +401,7 @@ class NaVILAInferenceConfig(InferenceConfig):
             try:
                 match = re.search(r"move forward (\d+) cm", outputs)
                 distance = int(match.group(1))
-            except:
+            except Exception:
                 distance = 25
             if (distance % 25) != 0:
                 distance = min([25, 50, 75], key=lambda x: abs(x - distance))
@@ -412,7 +412,7 @@ class NaVILAInferenceConfig(InferenceConfig):
             try:
                 match = re.search(r"turn left (\d+) degree", outputs)
                 degree = int(match.group(1))
-            except:
+            except Exception:
                 degree = 15
             if (degree % 15) != 0:
                 degree = min([15, 30, 45], key=lambda x: abs(x - degree))
@@ -423,7 +423,7 @@ class NaVILAInferenceConfig(InferenceConfig):
             try:
                 match = re.search(r"turn right (\d+) degree", outputs)
                 degree = int(match.group(1))
-            except:
+            except Exception:
                 degree = 15
             if (degree % 15) != 0:
                 degree = min([15, 30, 45], key=lambda x: abs(x - degree))

--- a/dexbotic/exp/rl/rl_trainer.py
+++ b/dexbotic/exp/rl/rl_trainer.py
@@ -517,7 +517,7 @@ class DexboticRLTrainer(DexboticTrainer):
             return [batch]
         try:
             original_batch_size = int(original_batch_size)
-        except:
+        except Exception:
             pass
         rollout_num = original_batch_size // num_segment
         batch_out = []

--- a/hardware/so101/bridge_server.py
+++ b/hardware/so101/bridge_server.py
@@ -47,7 +47,7 @@ class BridgeService(services_pb2_grpc.AsyncInferenceServicer):
         self.shutdown_event.clear()
         try:
             cv2.destroyAllWindows()
-        except:
+        except Exception:
             pass
         return services_pb2.Empty()
 

--- a/hardware/so101/convert_so101_to_dexdata.py
+++ b/hardware/so101/convert_so101_to_dexdata.py
@@ -51,7 +51,7 @@ def get_task_list(meta_dir):
                 try:
                     info = json.loads(line)
                     tasks.append(info.get("task", info.get("instruction", "")))
-                except:
+                except Exception:
                     continue
     return tasks
 


### PR DESCRIPTION
Replace bare `except:` with `except Exception:` across 4 files (8 sites).

**Why:** Bare `except:` catches `BaseException` including `KeyboardInterrupt` and `SystemExit`, which can prevent clean shutdown during training or hardware communication. `except Exception:` preserves all fallback behavior.

**Files:** `navila_exp.py` (4), `rl_trainer.py` (1), `bridge_server.py` (1), `convert_so101_to_dexdata.py` (1)