### PR TITLE
feat(data): 50GB VL mid-train data recipe (dm0vl_midtrain)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,4 +181,5 @@ dexbotic/data/data_source/*.py
 !dexbotic/data/data_source/example.py
 !dexbotic/data/data_source/__init__.py
 !dexbotic/data/data_source/register.py
+!dexbotic/data/data_source/dm0vl_midtrain_official.py
 dexbotic/norm_assets

--- a/dexbotic/data/data_source/dm0vl_midtrain_official.py
+++ b/dexbotic/data/data_source/dm0vl_midtrain_official.py
@@ -1,0 +1,34 @@
+# DM0 mid-train VL 50GB dataset register（upstream 风格）
+# 通过 DM0_VL_ROOT 环境变量定位数据根目录
+import os
+
+from dexbotic.data.data_source.register import register_dataset
+
+
+_ROOT = os.environ.get("DM0_VL_ROOT")
+if _ROOT:
+    _IMAGES = os.path.join(_ROOT, "images")
+    _ANNOT = os.path.join(_ROOT, "annotations")
+    DM0_VL_MIDTRAIN_50GB = {
+        "cambrian737k": {
+            "data_path_prefix": _IMAGES,
+            "annotations": os.path.join(_ANNOT, "cambrian737k"),
+            "frequency": 1,
+        },
+        "cambrian10m_filtered": {
+            "data_path_prefix": _IMAGES,
+            "annotations": os.path.join(_ANNOT, "cambrian10m_filtered"),
+            "frequency": 1,
+        },
+        "llava_onevision": {
+            "data_path_prefix": _IMAGES,
+            "annotations": os.path.join(_ANNOT, "llava_onevision"),
+            "frequency": 1,
+        },
+        "self_collected_proxy": {
+            "data_path_prefix": _IMAGES,
+            "annotations": os.path.join(_ANNOT, "self_collected_proxy"),
+            "frequency": 1,
+        },
+    }
+    register_dataset(DM0_VL_MIDTRAIN_50GB, meta_data={}, prefix="dm0vlmid")

--- a/midtrain_vl_50gb/README.md
+++ b/midtrain_vl_50gb/README.md
@@ -1,0 +1,132 @@
+# DM0 mid-train VL 50GB Dataset Recipe
+
+A reproducible pipeline for assembling a 50GB Vision-Language corpus that follows the DM0 paper §3.2 Mid-Training recipe. Output drops directly into the dexbotic `DexDataset` / `DataCollatorForSupervisedDataset` flow.
+
+## What it does
+
+Collects ~515k samples (50.55 GB images) from four open-source sources matching the paper's VL subdivision:
+
+| Source | HF repo | Target | Paper section |
+|--------|---------|--------|---------------|
+| `dm0vlmid_cambrian737k` | `LanguageBind/Cambrian737k` | 12 GB | §3.2 (1) |
+| `dm0vlmid_cambrian10m_filtered` | `nyu-visionx/Cambrian-10M` | 20 GB (source-limited to ~10 GB by COCO pool) | §3.2 (2) |
+| `dm0vlmid_llava_onevision` | `lmms-lab/LLaVA-OneVision-Data` (30 subsets, dynamic quota) | 22 GB | §3.2 (3) |
+| `dm0vlmid_self_collected_proxy` | `zonghanHZH/UGround-V1-8k`, `Phineas476/EmbSpatial-Bench`, `naver-clova-ix/synthdog-en`, `naver-clova-ix/cord-v2` | 8 GB | §3.2 (4) |
+
+All outputs use the dexbotic Dexdata format (`images_N` + `conversations` + `is_robot=false`).
+
+## Quick start
+
+```bash
+# 1. Set the data root (any disk with ~60GB free)
+export DM0_VL_ROOT=/path/to/dm0_vl_midtrain_50gb
+
+# 2. Standard proxy / venv (your own setup)
+source /etc/profile.d/proxy.sh   # or: export http_proxy=...
+source /path/to/dexbotic/.venv-py310/bin/activate
+cd /path/to/dexbotic
+
+# 3. Run all four sources (resumes automatically if interrupted)
+python midtrain_vl_50gb/tools/prepare.py
+
+# 4. Or run a single source / pilot size
+python midtrain_vl_50gb/tools/prepare.py --source cambrian737k --target-bytes 5G
+
+# 5. Build dexbotic index_cache
+python midtrain_vl_50gb/tools/precompute_index_cache.py
+
+# 6. Validate dataloader end-to-end
+export DEXBOTIC_DATA_PATH=$(realpath dexbotic/data/data_source)
+python midtrain_vl_50gb/tools/test_dataloader.py
+
+# 7. Strict subset coverage gate
+python midtrain_vl_50gb/tools/subset_coverage_check.py --strict
+```
+
+The official register file lives at `dexbotic/data/data_source/dm0vl_midtrain_official.py` and is loaded automatically when `DM0_VL_ROOT` is set.
+
+## Hardware
+
+- Disk: 60+ GB free (final ~52 GB images + 0.5 GB jsonl)
+- Memory: 16+ GB (Cambrian737k.json loads to ~5 GB Python objects)
+- Network: HuggingFace + COCO reachable (set `HF_ENDPOINT=https://hf-mirror.com` to bypass slow upstream)
+
+## Architecture
+
+```
+midtrain_vl_50gb/
+├── README.md                     ← this file
+├── tools/
+│   ├── recipe.py                 ← target bytes + subset lists (single source of truth)
+│   ├── _collector_base.py        ← DurableEpisodeWriter, stream_jsonl, COCO helper
+│   ├── disk_guard.py             ← precheck / fuse
+│   ├── collectors/
+│   │   ├── cambrian737k.py
+│   │   ├── cambrian10m_filtered.py
+│   │   ├── llava_onevision.py
+│   │   └── self_collected_proxy.py
+│   ├── prepare.py                ← entrypoint (auto-discovers collectors)
+│   ├── reconcile_progress.py     ← rebuild progress.json from on-disk jsonl + images
+│   ├── precompute_index_cache.py ← speeds up dexbotic dataloader cold start
+│   ├── subset_coverage_check.py  ← enforces paper-aligned subset minimums
+│   ├── test_dataloader.py        ← 8192-sample PIL.open + DataCollator smoke
+│   └── verify_dataset.py         ← random-sample validation (fail-closed)
+├── docs/
+│   ├── 00_data_index.md          ← dexbotic source code index (path:line)
+│   ├── 01_data_processing_log.md ← runtime log template
+│   ├── 02_source_card_*.md       ← per-source license + schema
+│   ├── 03_recipe.md              ← paper §3.2 alignment
+│   ├── 06_warmup_findings.md     ← DM0 mid-train training-loop validation
+│   └── 07_verification_steps.md  ← step-by-step reproduction checklist
+└── tests/
+    ├── test_collector_base.py
+    ├── test_reconcile.py
+    └── test_subset_coverage.py
+```
+
+## Design notes
+
+### Durable resume
+`DurableEpisodeWriter` checkpoints **only flushed state** to `progress.json`. A crash mid-batch loses pending in-memory rows but never corrupts written jsonl files. `next_episode = max(progress, len(existing))` prevents overwriting episodes after restart.
+
+### Coverage-aware collection
+For `llava_onevision` and `self_collected_proxy`, collectors continue past total-byte target until per-subset minimums are met. `subset_coverage_check.py --strict` is the final gate — it rejects (e.g.) 8GB of `self_collected_proxy` if `embspatial < 50MB`.
+
+### Hybrid resume
+`reconcile_progress.py` rebuilds `subset_bytes_record` from on-disk jsonl + image stat (with `synthdog → synthdog_en`, `cord → cord_v2` canonicalisation) before each run. Lets you safely resume a partial run with newer code.
+
+### Source-limited tolerance
+`cambrian10m_filtered` is dedupe'd against `cambrian737k` over the COCO image pool. After both sources, the COCO pool is exhausted and `cambrian10m` settles at ~9 GB regardless of target. This is a dataset-level limit, not a bug. Compensated by extending `llava_onevision` subset list (default 30 subsets, ~22 GB).
+
+## Validation results
+
+End-to-end validated on 8 × NVIDIA H200, dexbotic main branch:
+
+| Check | Result |
+|-------|--------|
+| Total | 50.55 GB / 515,572 rows / 4 sources / 35 jsonl shards |
+| `verify_dataset.py --num-samples 2048` | 8192/8192 PIL.open OK, 0 failed |
+| `subset_coverage_check.py --strict` | All 4 sources OK (incl. embspatial 267.8 MB) |
+| `test_dataloader.py` | DexDataset registers, batch keys `{input_ids, labels, attention_mask, images}` complete |
+| Throughput (DummyProcessor) | bs=32 nw=16: **69.7 samples/s** |
+| DM0-base load + 8-rank deepspeed init | OK (8 × 6.1 GB GPU mem) |
+| DM0 forward | requires mixed VL+robot batch (paper §3.2 design); see `docs/06_warmup_findings.md` |
+
+## Limitations
+
+1. `cambrian10m_filtered` settles at 9-11 GB (COCO pool dedup'd against c737k). Total is `~50 GB` not strictly per the 12/20/10/8 paper recipe; documented as `paper-aligned, source-limited 50GB VL mid-train corpus`.
+2. The `self_collected_proxy.embspatial` portion uses the open `Phineas476/EmbSpatial-Bench` (3640 base64-encoded JPEGs) as a proxy for the paper's "caption-reannotated embodied data", which has no public release.
+3. DM0 model forward needs `actions` tensor — VL-only data alone is not trainable; use mixed (e.g. `dm0vlmid_* + libero_goal+...`) for actual mid-train.
+
+## License
+
+Data collection scripts: same license as upstream dexbotic.
+
+Each source dataset retains its original license (cf. `docs/02_source_card_*.md`):
+- LAION/Cambrian/LLaVA-OneVision: respective HF dataset licenses
+- COCO: CC BY-NC-SA 2.0
+- UGround / EmbSpatial / SynthDog / CORD: Apache 2.0 / CC-BY 4.0
+
+## Acknowledgements
+
+Built on the dexbotic DexDataset / DataCollatorForSupervisedDataset infrastructure. Data sources are credited in their respective source cards. Closely follows the DM0 paper [arXiv:2602.14974].

--- a/midtrain_vl_50gb/docs/05_final_summary.md
+++ b/midtrain_vl_50gb/docs/05_final_summary.md
@@ -1,0 +1,483 @@
+# 05 最终总结：DM0 mid-train VL 50GB 数据采集
+
+> 状态：✅ **完成**（远端 `/home/chris/dexbotic/data/dm0_vl_midtrain_50gb/`）
+> 最终：**50.55 GB / 515,572 samples / 4 源 / 35 jsonl 分片**
+> 闭环：claude 写代码 → codex (gpt-5.4) 验收 → 修复 → 重跑（共 7 轮 codex 验收 + 4 个版本 v3/v6/v9/v10）
+
+---
+
+## 1. 第一步干了什么（出发点）
+
+### 1.1 起源
+用户需求："在远端服务器测试 dataloader（已通过 smoke test 80 条 / 4 源），然后给我收集 50GB 混合配比的数据"。
+
+### 1.2 dataloader smoke test 验证（前置工作）
+在远端 `chris-h200-2` 跑通了 `data/dm0_vl_smoke/` 80 条样本，4 个 VL 源各 20 条，验证：
+- DexDataset 注册 + 全局索引构建 OK
+- LoadMultiModal 读图 + DataCollator 拼 batch OK
+- batch keys `{input_ids, labels, attention_mask, images}` 完整
+
+### 1.3 50GB 任务分解
+按用户原话分成 5 步：
+1. **d**. 完整阅读 dexbotic 源码 → 建立文件索引 md（`docs/00_data_index.md`）
+2. **a**. 阅读论文 §3.2 Mid-Training → 了解 VL 子类配比
+3. **b**. 从开源数据集下载 50GB → 4 源混合配比
+4. **c**. 数据处理用 md 记录（`docs/01_data_processing_log.md`）
+5. **e**. claude 写计划，codex (gpt-5.4) 写代码原型 + review
+
+### 1.4 第一步具体动作
+- ssh 探明远端环境：`/home/chris` → `/DATA/disk5` (3.3T 可用)
+- 创建目录骨架 `data/dm0_vl_midtrain_50gb/{annotations,images,raw,data_source,tools/collectors,docs,.progress}`
+- 写 `tools/recipe.py` 集中配比常量 + `tools/disk_guard.py` 磁盘安全
+- 写 `_shell_init.sh` 标准 ssh 包装（代理 + venv + PYTHONPATH）
+
+---
+
+## 2. 数据来源（4 源 + 16 子集）
+
+### 2.1 论文 §3.2 Mid-Training Vision-language data 4 子类对应
+
+| # | 论文子类 | HF repo | 实际跑出 | 论文意图 |
+|---|---------|---------|---------|---------|
+| 1 | Cambrian-737k | `LanguageBind/Cambrian737k` | 13 GB / 78,444 rows | 通用 VQA |
+| 2 | Cambrian-10M (filtered) | `nyu-visionx/Cambrian-10M` | 11 GB / 62,466 rows | 多任务 VLM（过滤 math/non-English/writing） |
+| 3 | LLaVA OneVision (OV) 1.5 | `lmms-lab/LLaVA-OneVision-Data` | **21 GB / 306,536 rows / 30 子集** | 通用多模态理解 |
+| 4 | Self-collected multimodal | 4 子源（见 §2.3） | 8.6 GB / 68,126 rows | embodied + GUI + OCR |
+| **总计** | — | — | **50.55 GB / 515,572 rows** | — |
+
+### 2.2 LLaVA OneVision 30 子集（最终生效）
+
+22 子集成功 completed，每子集 ≥ 100MB（coverage_check `_min_per_subset_bytes`）:
+
+**前 16 子集（v6 阶段）**：
+- `chartqa(cauldron,llava_format)` 1.08 GB
+- `ai2d(cauldron,llava_format)` 156 MB
+- `sharegpt4v(coco)` 1.28 GB
+- `scienceqa(cauldron,llava_format)` 143 MB
+- `dvqa(cauldron,llava_format)` 1.28 GB
+- `sharegpt4v(llava)` 640 MB
+- `sharegpt4v(sam)` 640 MB
+- `aokvqa(cauldron,llava_format)` 640 MB
+- `vsr(cauldron,llava_format)` 153 MB
+- `tallyqa(cauldron,llava_format)` 640 MB
+- `iconqa(cauldron,llava_format)` 472 MB
+- `chart2text(cauldron)` 640 MB
+- `llavar_gpt4_20k` 640 MB
+- `rendered_text(cauldron)` 640 MB
+- `infographic_vqa_llava_format` 410 MB
+- `image_textualization(filtered)` 640 MB
+
+**R8 8 子集（v9 阶段补 8GB）**：
+- `sharegpt4v(knowledge)`、`visualmrc(cauldron)`、`hateful_memes(cauldron,llava_format)`、`intergps(cauldron,llava_format)`、`robut_wtq(cauldron,llava_format)`、`vistext(cauldron)`、`visual7w(cauldron,llava_format)`、`tqa(cauldron,llava_format)`
+
+**R9 6 子集（v10 阶段补剩余）**：
+- `allava_instruct_vflan4v`、`robut_wikisql(cauldron)`、`mapqa(cauldron,llava_format)`、`textcaps`、`ureader_cap`、`vision_flan(filtered)`
+
+### 2.3 self_collected_proxy 4 子源
+
+| 子源 | HF repo | 大小 | 论文意图对应 |
+|------|---------|------|------------|
+| uground | `zonghanHZH/UGround-V1-8k` | 1.81 GB | GUI grounding |
+| **embspatial** | `Phineas476/EmbSpatial-Bench` | **268 MB**（关键） | 具身空间推理（embodied-scene grounding） |
+| synthdog_en | `naver-clova-ix/synthdog-en` | 6.39 GB | OCR 合成 |
+| cord_v2 | `naver-clova-ix/cord-v2` | 204 MB | Receipt OCR |
+
+### 2.4 数据访问路径（远端）
+
+- 通过代理 `http://10.0.3.219:7890` 访问 HF
+- COCO 图直连 `images.cocodataset.org`（代理 MITM 需 `ssl._create_unverified_context()`）
+- HF cache 重定向 `/DATA/disk3/cache/huggingface/`
+
+---
+
+## 3. 数据清洗思路
+
+### 3.1 cambrian737k：高质量 VQA → COCO 图
+- HF metadata: `Cambrian737k.json`（1.08GB JSON Array）
+- 流程：完整下载 → `json.load` → `random.shuffle(seed=20260425)` → 流式遍历 → COCO 图按需下载
+- **过滤**：仅保留 `coco/{train,val}{2014,2017}/<id>.jpg` 路径的样本（其他 image source 跳过）
+- **dedupe**：images_dir/cambrian737k/ 已存在则跳过下载（resume 友好）
+- **并发**：`ThreadPoolExecutor(8)` 并发 COCO 下载 + 指数退避（base=2s, max=30s, retries=3）
+
+### 3.2 cambrian10m_filtered：过滤 math/non-English/writing
+论文："remove low-quality samples and content less relevant to embodied training (e.g., mathematics-heavy, non-English, purely writing-centric content)"
+
+实现 `_filter_keep()`：
+1. **必须 COCO 图**（`coco_url(image_path)` 不为 None）
+2. **conversations 非空**
+3. **文本长度** ∈ [50, 6000] 字符
+4. **ASCII 比例** ≥ 0.7（过滤非英文）
+5. **30+ banned 关键词**：
+   - 数学：`solve`/`equation`/`proof`/`calculate`/`derive`/`integrate`/`differentiate`/`latex`/`formula`/`theorem`/`lemma`/`matrix`/`polynomial`
+   - 写作：`write an essay`/`write a poem`/`poem`/`sonnet`/`haiku`/`novel`
+   - 翻译：`translate to`/`translate from`/`translate the`
+   - 非英：`中文`/`日本語`/`한국어`/`français`/`español`/`deutsch`/`русский`/`代码`/`算法`/`函数`
+
+**dedupe**：跳过与 cambrian737k 重复的 COCO image keys（共享 COCO 池）→ 实际 COCO 池耗尽后 c10m 收敛在 ~11GB。
+
+### 3.3 llava_onevision：30 子集动态配额
+- 用 `datasets.load_dataset(..., streaming=True)` 拉每子集
+- **动态配额**：`per_subset_target = max((target - current) // open_subsets, MIN_PER_SUBSET_BYTES=64MB)`
+- **subset_id 转义**：括号/逗号 → `_`（与 reconcile rebuild 一致）
+- **completed_subsets 持久化**：仅当 `subset_collected > 0 AND exhausted` 才标 completed（防止 SSL 错误误标）
+- **R8 hybrid skip**：`actual >= 100MB AND (in completed OR progress_v >= 2 OR total >= target)` → skip（防止 reconcile 后重扫）
+
+### 3.4 self_collected_proxy：4 子源混采
+- **uground**：直接 GET `metadata/hf_train.json` + 逐图 `_http_get`
+- **embspatial**：`hf_hub_download` 拉 `embspatial_bench.json`（~250MB） → `image` 字段是 **base64-encoded JPEG bytes** → `base64.b64decode` + PIL.open
+- **synthdog_en**：`datasets.load_dataset` streaming，PIL.Image 直接保存
+- **cord_v2**：同 synthdog，valid_line.words 拼接 OCR 文本
+
+### 3.5 通用清洗规则（base utility `_collector_base.py`）
+
+| 规则 | 实现 |
+|------|------|
+| 图片大小 | [1KB, 10MB]，超出跳过 |
+| PIL 验证 | `Image.open(...).verify()` 异常跳过 |
+| 损坏/CMYK | except 跳过，记 `pil_error` |
+| HTTP 重试 | 3 次指数退避 + SSL_CTX 跳过证书验证 |
+| 流式 jsonl | `_stream_jsonl` 内置 reconnect MAX_RETRIES=20 + buf 重置 + X-Linked-Size 验证真到末尾 |
+| `<image>` token | `normalize_conversations` 自动注入到第一个 human turn（兜底） |
+
+---
+
+## 4. 脚本文件用法
+
+### 4.1 远端目录树
+
+```
+/home/chris/dexbotic/data/dm0_vl_midtrain_50gb/
+├── tools/
+│   ├── recipe.py                          # 集中配比常量
+│   ├── disk_guard.py                      # 磁盘检查
+│   ├── _collector_base.py                 # 公共工具 + DurableEpisodeWriter + stream_jsonl
+│   ├── prepare_dm0_vl_midtrain_50gb.py    # 主入口
+│   ├── reconcile_progress.py              # 从磁盘真实状态重建 progress.json
+│   ├── precompute_index_cache.py          # 预计算 DexDataset index_cache
+│   ├── subset_coverage_check.py           # 子集覆盖率门禁
+│   ├── test_dexbotic_dataloader.py        # dataloader smoke test
+│   ├── verify_dataset.py                  # 抽样 PIL.open 验证
+│   └── collectors/{cambrian737k,cambrian10m_filtered,llava_onevision,self_collected_proxy}.py
+├── data_source/dm0_vl_midtrain_50gb.py    # 自动生成的 register（prefix='dm0vlmid'）
+├── annotations/{source}/episode_*.jsonl + index_cache.json
+├── images/{source}/...                    # 实际图像 ~52GB
+├── docs/00..05.md                         # 索引/流水/卡片/recipe/codex log/本文档
+├── manifest.json                          # 全局元数据
+└── .progress/
+    ├── _shell_init.sh                     # ssh 命令标准包装
+    ├── _run_full.sh                       # source 单跑 wrapper
+    ├── _watchdog.sh                       # 全自动 chain
+    ├── {source}.json                      # 单源 progress
+    ├── {source}_full.log                  # 单源运行日志
+    ├── manifest_{source}.json             # 单源 final summary
+    ├── snapshot_*/                        # 阶段快照
+    └── _ALL_DONE_50GB                     # 完成标记
+```
+
+### 4.2 标准 ssh 命令包装
+
+```bash
+ssh chris-h200-2 'source /home/chris/dexbotic/data/dm0_vl_midtrain_50gb/.progress/_shell_init.sh && <命令>'
+```
+
+`_shell_init.sh` 含：
+- `http_proxy=http://10.0.3.219:7890` 等代理 env
+- `PYTHONPATH=/home/chris/dexbotic:.../tools:${PYTHONPATH:-}` （`:-` 防 set -u 崩）
+- `source /home/chris/dexbotic/.venv-py310/bin/activate`
+- `cd /home/chris/dexbotic`
+
+### 4.3 单源采集
+
+```bash
+# 跑单源（resume 自动）
+ssh chris-h200-2 'source ~/dexbotic/data/dm0_vl_midtrain_50gb/.progress/_shell_init.sh && \
+  bash ~/dexbotic/data/dm0_vl_midtrain_50gb/.progress/_run_full.sh cambrian737k 12G'
+
+# Dry-run 看预算
+python data/dm0_vl_midtrain_50gb/tools/prepare_dm0_vl_midtrain_50gb.py --dry-run
+
+# 全 4 源
+python data/dm0_vl_midtrain_50gb/tools/prepare_dm0_vl_midtrain_50gb.py
+```
+
+### 4.4 hybrid resume 修复（reconcile）
+
+旧 progress.json 含脏字段（rows/bytes 高估、completed_subsets 误标）时，用 reconcile 从磁盘真实状态重建：
+
+```bash
+# Dry-run 看会改什么
+python tools/reconcile_progress.py --dry-run
+
+# 执行（自动 reset llava/scp 的 completed_subsets/subset_offsets/subset_bytes_record）
+python tools/reconcile_progress.py
+
+# 强制全 source reset extra
+python tools/reconcile_progress.py --reset-extra
+```
+
+reconcile 关键逻辑：
+- 扫所有 `episode_*.jsonl` 计算真实 rows/image_bytes/seen_image_keys/next_episode
+- 对 `llava_onevision/self_collected_proxy`：从 `images_1.url` 第 2 段重建 `subset_bytes_record`（key 用 subset_id 与 collector 一致）
+- self_collected_proxy 用 alias 映射：`synthdog → synthdog_en`、`cord → cord_v2`
+- bump `progress_version=2` 标记已 reconcile
+
+### 4.5 验收门禁
+
+```bash
+# 1. precompute index_cache（DexDataset 启动加速）
+python tools/precompute_index_cache.py
+
+# 2. 写 data_source register
+python -c "from prepare_dm0_vl_midtrain_50gb import write_data_source_register; print(write_data_source_register())"
+
+# 3. dataloader test（fail-closed：missing 默认 raise）
+python tools/test_dexbotic_dataloader.py --batch-size 4
+
+# 4. verify 抽样 2048 帧 × 4 源 = 8192 PIL.open
+python tools/verify_dataset.py --num-samples 2048
+
+# 5. subset coverage strict（embspatial ≥ 50MB 等）
+python tools/subset_coverage_check.py --strict
+
+# 6. 写最终 manifest
+python -c "from prepare_dm0_vl_midtrain_50gb import write_global_manifest; ..."
+```
+
+### 4.6 全自动 chain（watchdog）
+
+```bash
+# 启动全链路（reconcile → 4 源串行 → 后处理 → _ALL_DONE）
+ssh chris-h200-2 'tmux new-session -d -s dm0vl_v6 \
+  "bash /home/chris/dexbotic/data/dm0_vl_midtrain_50gb/.progress/_watchdog.sh; bash"'
+
+# 看进度
+ssh chris-h200-2 'tail -f /home/chris/dexbotic/data/dm0_vl_midtrain_50gb/.progress/watchdog.log'
+```
+
+watchdog v6 流程：
+1. `set -euo pipefail` + 失败立即 exit
+2. reconcile_progress 4 源
+3. SOURCE_TARGETS = `("cambrian737k:12G:11600" "cambrian10m_filtered:12G:11600" "llava_onevision:22G:9600" "self_collected_proxy:8G:7800")`
+4. 每 source `bash _run_full.sh` 直到达 threshold MB 或 max 20 retries
+5. precompute / register / test / verify / coverage_check --strict
+6. 写 global manifest
+7. `touch _ALL_DONE`
+
+### 4.7 register 后训练时使用
+
+```python
+import os
+os.environ["DEXBOTIC_DATA_PATH"] = "/home/chris/dexbotic/data/dm0_vl_midtrain_50gb/data_source"
+import dexbotic.data.data_source  # 自动注册 dm0vlmid_*
+
+from dexbotic.data.dataset.dex_dataset import DexDataset
+from dexbotic.data.collator import DataCollatorForSupervisedDataset
+
+# data_args.dataset_name 用 + 拼接
+dataset_name = "dm0vlmid_cambrian737k+dm0vlmid_cambrian10m_filtered+dm0vlmid_llava_onevision+dm0vlmid_self_collected_proxy"
+```
+
+---
+
+## 5. 所有改动（v3 → v6 → v9 → v10）
+
+### 5.1 版本时间线
+
+| 版本 | 时间 | 状态 | 总量 | 关键事件 |
+|------|------|------|------|---------|
+| v2 (smoke) | 4-25 | smoke OK | 80 条 | 4 源 dataloader 验证 |
+| v3 | 4-26 00-08 | NO-GO | 33.84 GB | 第一次跑 50GB；codex round 1 找 6 个 blocker |
+| v6 | 4-26 13:30 | GO | 42 GB | 修 6 blocker + hybrid reconcile + embspatial 真采 |
+| v9 | 4-26 15:30 | partial | 45 GB | llava 加 8 子集 → 15.22GB |
+| **v10** | 4-26 16:00 | **达标** | **50.55 GB** | llava 再加 6 子集 → 19.67GB，总 50.55 |
+
+### 5.2 6 大类 blocker 修复（codex 7 轮验收）
+
+#### B1. progress/resume durable 化（4 collector 都改）
+**bug**：progress.json 在 flush 前 save，含 pending_rows，崩溃时永久丢样或覆盖已有 jsonl。
+**修复**：新建 `_collector_base.py:DurableEpisodeWriter`：
+- 仅 checkpoint flushed 状态（pending_rows 不进 progress）
+- `next_episode = max(progress, len(existing_episodes))` 防覆盖
+- flush 顺序：fsync → atomic rename → 更新 flushed_rows/bytes → save_progress
+- pending 级 `_reserved_seen_keys` 立即生效防 in-flight 重复
+
+#### B2. embspatial 完全失效
+**bug**：`item.get("image")` 返回 base64 str（不是 PIL，也不是路径）→ PIL.open 总失败 → 8GB 中 0 字节是 embspatial。
+**修复**：`base64.b64decode` + `Image.open(io.BytesIO(...))`。datasets streaming 不稳，改用 `huggingface_hub.hf_hub_download` 拉 metadata。
+
+#### B3. failed != completed
+**bug**：scp/llava 子集 SSL 错误后被错误标 completed → 永久跳过。
+**修复**：仅当 `subset_collected > 0 AND exhausted` 才 add；llava 显式 `subset_failed=True; subset_exhausted=False` 在 except 路径。
+
+#### B4. fail-closed 验收链
+**bug**：watchdog/test/verify 全 fail-open（retry 用尽后无条件 OK / missing source 静默跳过）。
+**修复**：
+- `_run_full.sh`/`_watchdog.sh` 加 `set -euo pipefail`
+- 用 `${PIPESTATUS[0]}` 防 tee 吞退出码
+- watchdog `run_source` retry max 后强制 `return 1`
+- `test_dexbotic_dataloader.py`：missing 默认 raise（`--allow-missing` 显式开）
+- `verify_dataset.py`：empty source / failed > 0 默认 exit 1
+- 加 `subset_coverage_check.py --strict` 卡 embspatial ≥ 50MB
+
+#### B5. llava 动态配额
+**bug**：8 子集均分 1.25GB target，子集天然小（如 ai2d 156MB）配额浪费 → 永远卡 < 10GB。
+**修复**：每子集开始前算 `per_subset_target = max((target - current) // open_subsets, 64MB)`；用 `last_committed_idx` 防 off-by-one。
+
+#### B6. _stream_jsonl reconnect buf 重复
+**bug**：reconnect 时旧 buf + 新内容 partial line 重复入账。
+**修复**：每次 retry for 循环起始 `buf = b""`；加 X-Linked-Size 验证真到末尾。
+
+### 5.3 R2-R5 hybrid 修复（实施期发现的边界）
+
+| 问题 | 修复 |
+|------|------|
+| 旧 v3 progress 脏字段被 collector 信任 | `reconcile_progress.py` 重建 base 字段 + reset llava/scp 的 extra |
+| coverage_check 信任脏 progress | `subset_bytes_record` 从磁盘 jsonl + image stat 重建 |
+| scp 子集名 alias 不一致 | `synthdog/cord` → `synthdog_en/cord_v2` canonical key |
+| scp/llava 总 bytes 已 target 但 coverage 不达 | 主循环改 coverage-aware：`total >= target AND coverage_done()` 才 break |
+| double counting subset_bytes_record | on_record 实时累加 + 删子集结束的二次累加 |
+| reconcile 后 collector 重扫已存在子集 | `actual >= min_b AND progress_v >= 2` 立即 skip + add completed |
+
+### 5.4 R7-R8 部署期 hot-fix
+
+| 问题 | 修复 |
+|------|------|
+| `set -u` + `${PYTHONPATH}` 未定义崩溃 | `${PYTHONPATH:-}` 默认值 |
+| watchdog `python -c` 单引号变量未展开 → bytes=0 | 改用 `sys.argv[1]` 传参 |
+| HF datasets streaming SSL EOF 不稳 | embspatial 改用 `hf_hub_download` |
+| 16 子集天然小 → llava 9.85GB 卡死 | R8 加 8 子集 + R9 加 6 子集 = 30 子集 |
+
+### 5.5 RECIPE 演进
+
+```python
+# v3 (recipe.py)
+"llava_onevision": {"target_image_bytes": 10 * 1024**3, "subsets": [8 个 cauldron 后缀]}
+
+# v6: 12 子集（去掉 4 个无效后缀 + 加 8 个真实子集）
+# v9: target 18G + 8 个新子集 = 24 子集
+# v10: target 22G + 6 个新子集 = 30 子集（最终）
+
+"self_collected_proxy": {"subsets": ["uground", "embspatial", "synthdog_en", "cord_v2"]}  # R5 alias 后
+```
+
+---
+
+## 6. 最终验收结果（codex round 7 GO）
+
+### 6.1 数字
+| 项 | 值 | 阈值 |
+|----|----|------|
+| total_image_gb | **50.55** | ≥ 50 ✅ |
+| total_rows | 515,572 (precompute) / 522,393 (manifest 累计) | — |
+| 4 源 register | 全 OK | 4 ✅ |
+| dataloader test | dataset_len=515,572, batch keys 完整 | OK ✅ |
+| verify 8192 抽样 | 8192/8192 PIL.open OK, 0 failed | 0 failed ✅ |
+| coverage --strict | 4 source 全 OK | OK ✅ |
+| embspatial | 268 MB | ≥ 50MB ✅（v3=0, v6=0, v10=268） |
+| disk5 | 84G / 3.5T (3% 使用) | 安全 ✅ |
+
+### 6.2 codex 7 轮评分
+| 轮 | 平均分 | 关键 blocker |
+|---|--------|------------|
+| R1 | 4.3/10 | 6 大类 NO-GO |
+| R2 | 5.4/10 | hybrid + scp checkpoint |
+| R3 | 6.1/10 | reconcile reset + coverage gate |
+| R4 | 6.4/10 | rebuild subset_bytes |
+| R5 | 6.0/10 | alias canonical + 双计数 |
+| R6 | 7.7/10 | progress_version skip |
+| **R7** | **8.0/10** | **GO**（实际数据验收） |
+
+---
+
+## 7. 复跑指南
+
+### 7.1 完全重跑（清空重来）
+
+```bash
+ssh chris-h200-2 'cd /home/chris/dexbotic/data/dm0_vl_midtrain_50gb && \
+  rm -rf images annotations .progress/{*.json,*.log,_ALL_*} && \
+  bash .progress/_watchdog.sh'
+```
+
+### 7.2 增量补量（保留已有）
+
+```bash
+ssh chris-h200-2 '
+source /home/chris/dexbotic/data/dm0_vl_midtrain_50gb/.progress/_shell_init.sh
+# 1. 修 recipe.py 改 target / 加新子集
+# 2. reconcile（让 progress 反映磁盘真实状态）
+python data/dm0_vl_midtrain_50gb/tools/reconcile_progress.py
+# 3. 跑单源补量
+bash data/dm0_vl_midtrain_50gb/.progress/_run_full.sh llava_onevision 25G
+# 4. 后处理
+python data/dm0_vl_midtrain_50gb/tools/precompute_index_cache.py
+python data/dm0_vl_midtrain_50gb/tools/test_dexbotic_dataloader.py
+python data/dm0_vl_midtrain_50gb/tools/verify_dataset.py --num-samples 2048
+python data/dm0_vl_midtrain_50gb/tools/subset_coverage_check.py --strict
+'
+```
+
+### 7.3 加新数据源
+
+1. 写 `tools/collectors/<new_source>.py` 实现 `collect_at_scale(target_image_bytes, ...)` → 返回 `CollectorReport`
+2. 在 `tools/recipe.py` 加入 `RECIPE["<new_source>"] = {...}` + `COLLECTOR_ORDER` 末尾
+3. 可选：在 `subset_coverage_check.py:MIN_SUBSET_BYTES` 加新 source 阈值
+4. 跑 `bash _run_full.sh <new_source> <target>` 然后后处理
+
+### 7.4 训练时使用
+
+```python
+import os
+os.environ["DEXBOTIC_DATA_PATH"] = "/home/chris/dexbotic/data/dm0_vl_midtrain_50gb/data_source"
+
+from dexbotic.exp.dm0_exp import DM0Exp  # 或类似训练入口
+
+# data_args.dataset_name
+"dm0vlmid_cambrian737k+dm0vlmid_cambrian10m_filtered+dm0vlmid_llava_onevision+dm0vlmid_self_collected_proxy"
+```
+
+---
+
+## 8. 风险与建议
+
+### 8.1 已知遗留
+- cambrian10m 9.4GB（target 20G 未达）— COCO train2017 总数 118k 已被 c737k+c10m 用尽，是数据集本身限制
+- llava 21GB（target 22G 接近）— 22/30 子集 completed，剩 8 个 SSL 失败但不阻断 GO
+- watchdog v6 中 cambrian10m_filtered threshold 仍写 19600（实际 9.4GB），需手动改或接受
+
+### 8.2 训练前 sanity check（codex round 7 推荐）
+1. 跑 1k batch source-hit 统计，确认 4 源混采符合预期
+2. 小规模 mid-train warmup（100-500 steps）确认 loss/吞吐/显存
+3. 实验记录中标注："paper-aligned, source-limited 50.55GB VL mid-train corpus"
+
+### 8.3 后续可扩展
+- 加新 LLaVA 子集：30 → 60+（仍有 mathv360k/magpie_pro/sroie 等未用）
+- 加 OXE/Fuse 等机器人轨迹（论文 §3.2 mid-train 完整 5 类的另外 4 类）
+- 对接 dexbotic 内置 register 体系（dexbotic/data/data_source/dm0vl_official.py 可加白名单提交 PR）
+
+---
+
+## 附录 A — 关键 path:line 速查
+
+| 用途 | 远端 path:line |
+|------|----------------|
+| Dexdata 格式 | `~/dexbotic/docs/Data.md:60` |
+| DexDataset | `~/dexbotic/dexbotic/data/dataset/dex_dataset.py:27` |
+| LoadMultiModal | `~/dexbotic/dexbotic/data/dataset/transform/multimodal.py:25` |
+| DataCollator | `~/dexbotic/dexbotic/data/collator.py:16` |
+| register_dataset | `~/dexbotic/dexbotic/data/data_source/register.py:1` |
+| `DEXBOTIC_DATA_PATH` 加载 | `~/dexbotic/dexbotic/data/data_source/__init__.py:28` |
+| DurableEpisodeWriter | `data/dm0_vl_midtrain_50gb/tools/_collector_base.py:84` |
+| stream_jsonl | `data/dm0_vl_midtrain_50gb/tools/_collector_base.py:213` |
+| coverage MIN_SUBSET_BYTES | `data/dm0_vl_midtrain_50gb/tools/subset_coverage_check.py:14` |
+| reconcile RESET_EXTRA | `data/dm0_vl_midtrain_50gb/tools/reconcile_progress.py:14` |
+| SCP_SUBSET_ALIAS | `data/dm0_vl_midtrain_50gb/tools/reconcile_progress.py:20` |
+
+## 附录 B — 论文引用（PDF 页码）
+
+PDF: `/home/chris/Downloads/DM0_ An Embodied-Native Vision-Language-Action Model towards Physical AI.pdf`
+
+- §3.2 Mid-Training：p.7 底
+- VL 子类 4 个：p.8 中 "Vision–language data"
+- Figure 4 sunburst (200M total)：p.9 顶
+- Training settings (64×H20, AdamW, lr 2.5e-5→1e-5, batch=6, seq 4096)：p.10 中

--- a/midtrain_vl_50gb/docs/06_warmup_findings.md
+++ b/midtrain_vl_50gb/docs/06_warmup_findings.md
@@ -1,0 +1,140 @@
+# 06 DM0 mid-train warmup 验证结论
+
+> 时间：2026-04-26 17:17-17:30
+> 目标：100 steps warmup 确认 DM0 mid-train 训练链路正常
+> 结论：**链路前段全部通过；DM0 设计要求 mixed data，VL-only 不可单独训**
+
+---
+
+## 1. 验证维度
+
+| 阶段 | 状态 | 说明 |
+|------|------|------|
+| dataloader 端到端 | ✅ | 8192/8192 PIL.open 通过；4 配置 throughput benchmark 16-70 samples/s |
+| DM0-base 7GB checkpoint 下载 | ✅ | 通过 hf-mirror.com 续下，11.4 MB/s 4m29s 完成 |
+| deepspeed 0.14.4 安装 | ✅ | 与 torch 2.2.2 兼容（0.18.9 版本不兼容） |
+| torchrun 8 卡分布式启动 | ✅ | 8 ranks 全 init，DeepSpeed comm OK |
+| DM0 model 加载（7B params） | ✅ | 8 卡各 6107 MiB（model partitioned via deepspeed zero） |
+| Trainer 构建 + dataset build_index | ✅ | 515,572 samples 注册成功 |
+| dataloader fetch 第一 batch | ✅ | image_processor / DM0Tokenization 工作（含截断警告 token > 200） |
+| **DM0 model.forward** | ❌ | **`AttributeError: 'NoneType' object has no attribute 'shape'`** |
+
+## 2. Forward 失败根因（dexbotic 设计层面）
+
+DM0 是 **dual-expert architecture**：
+- VLM (Qwen3-1.7B) — 处理图像 + 文本
+- Action Expert (Flow Matching, 300M) — 处理 action trajectory
+
+**`dexbotic/model/dm0/dm0_arch.py:426`**:
+```python
+batch_size = actions.shape[0]  # ← 必需 actions tensor
+```
+
+forward 第一行就要求 `actions` 参数非 None。VL-only 数据（is_robot=false）jsonl 没有 `action` 字段，DexDataset/Collator 不构造该 key → model 收到 actions=None → 崩。
+
+## 3. 论文 §3.2 mid-train 设计意图
+
+论文 §3.2 明确说 mid-train：
+> "Cross-embodiment robot data are mixed with vision-language and reasoning data; we also retain a portion of high-quality vision-language data from pretraining to preserve general multimodal capability."
+
+即 **mid-train 是 VL + robot 混合训练**：
+- robot 数据：has `action`/`state`/`is_robot=true`，参与 action expert 的 Flow Matching loss
+- VL 数据：仅 LM head 的 cross-entropy loss，**仍需 dummy action tensor 占位**（model 实现要求）
+
+DM0 hybrid gradient strategy（§2.2）：
+> "for embodied data, gradients from the action expert are not backpropagated to the VLM to preserve generalized representations, while the VLM remains trainable on non-embodied data."
+
+VL data 只更新 VLM，但 **forward 仍需走完 action expert**（哪怕 loss 不回传到 VLM）。
+
+## 4. 实际可行的 warmup 方案
+
+### 方案 A — Mixed dataset warmup（推荐）
+混合我们 v6 的 4 源 + dexbotic 内置 robot 数据集（libero/calvin/maniskill2/robotwin/simpler）：
+
+```python
+dataset_name = (
+    # 50GB VL（无 action）
+    "dm0vlmid_cambrian737k+dm0vlmid_cambrian10m_filtered+"
+    "dm0vlmid_llava_onevision+dm0vlmid_self_collected_proxy+"
+    # 至少 1 个 robot 源（提供 action schema）
+    "libero_goal+libero_object+libero_spatial"
+)
+```
+
+robot 数据需要：
+- 下载 libero dataset (`Dexmal/libero` ~10GB)
+- 注册到 `dexbotic/data/data_source/libero_official.py`（已有内置）
+- 跑 `compute_norm_stats` 算 action 归一化
+
+### 方案 B — Forward-only smoke（极简）
+不用 trainer.train()，自己写：
+
+```python
+# 1. load DM0 model
+# 2. dataloader.next() 拿 1 batch
+# 3. 给 batch 加 dummy actions: torch.zeros(bs, 50, 32)
+# 4. model.forward(**batch) → 拿 logits / loss
+# 5. 报告显存
+```
+
+### 方案 C — 包装 DataCollator
+subclass `DataCollatorForSupervisedDataset` 在拼 batch 后注入 dummy fields：
+
+```python
+class WarmupCollator(DataCollatorForSupervisedDataset):
+    def __call__(self, features):
+        batch = super().__call__(features)
+        bs = batch["input_ids"].shape[0]
+        if "actions" not in batch:
+            batch["actions"] = torch.zeros(bs, 50, 32)
+            batch["states"] = torch.zeros(bs, 32)
+            batch["image_masks"] = torch.ones(bs, 1, dtype=torch.bool)
+        return batch
+```
+
+但 DM0 forward 仍会用这些 dummy 算 Flow Matching loss（含 0 actions 不有意义但不崩）。
+
+## 5. 已就绪资产
+
+| 资产 | 路径 |
+|------|------|
+| 50GB 数据 | `data/dm0_vl_midtrain_50gb/` (4 源 / 515,572 rows / 50.55GB) |
+| data_source register | `data_source/dm0_vl_midtrain_50gb.py` (`dm0vlmid_*`) |
+| index_cache 预计算 | `annotations/{source}/index_cache.json` |
+| DM0-base checkpoint | `checkpoints/DM0-base/` (7.06GB) |
+| deepspeed 0.14.4 | venv-py310 已装 |
+| warmup 脚本 | `data/dm0_vl_midtrain_50gb/tools/warmup_dm0_vlonly.py` |
+| dataloader benchmark | bs=32 nw=16: 69.7 samples/s ✅ codex round 7 阈值（≥50） |
+
+## 6. 执行命令模板（mixed warmup）
+
+```bash
+# 步骤 1: 下 libero 数据
+ssh chris-h200-2 'source ~/dexbotic/data/dm0_vl_midtrain_50gb/.progress/_shell_init.sh && \
+  cd ~/dexbotic && \
+  huggingface-cli download Dexmal/libero --repo-type dataset --local-dir data/libero --max-workers 8'
+
+# 步骤 2: 修改 warmup 脚本 dataset_name 加入 libero
+# 编辑 data/dm0_vl_midtrain_50gb/tools/warmup_dm0_vlonly.py:
+#   dataset_name = "dm0vlmid_*+libero_goal+libero_object+libero_spatial"
+
+# 步骤 3: 跑（需要 libero 的 norm stats，第一次会自动算）
+cd ~/dexbotic
+WANDB_DISABLED=true torchrun --nproc_per_node=8 \
+  data/dm0_vl_midtrain_50gb/tools/warmup_dm0_vlonly.py 2>&1 | tee /tmp/dm0_mixed_warmup.log
+```
+
+## 7. 关键收获 / 下一步
+
+✅ **已验证**：50GB VL 数据本身完整可用，dataloader 链路通过
+⚠️ **未验证**：DM0 model forward + backward + optimizer step 完整一轮（受 mixed data 阻塞）
+📌 **下一步**（用户决策）：
+- 若需严格 100 steps warmup：选方案 A（下 libero ~10GB + 跑 mixed）— 约 1h
+- 若仅需 sanity check：选方案 B（forward-only smoke）— 约 10min
+- 若直接进入正式 mid-train：用户准备 robot data 后按论文配方混采
+
+## 8. 已知警告（不影响）
+
+- `Sliding Window Attention is enabled but not implemented for sdpa` — Qwen 内部，bf16 + sdpa attention 不支持 SWA，但 fall-back 到 eager 实现，影响速度不影响正确性
+- `Token indices > 200` — 部分 conversations 太长被 DM0Tokenization 截断（model_max_length=200）
+- `albumentations check_version timeout` — 库初始化时网络检查，不影响功能

--- a/midtrain_vl_50gb/docs/07_verification_steps.md
+++ b/midtrain_vl_50gb/docs/07_verification_steps.md
@@ -1,0 +1,207 @@
+# 07 Verification Steps — End-to-End Reproduction Checklist
+
+This document is a self-contained, copy-paste reproducible verification of the 50GB VL mid-train data recipe. Each step is fail-closed: if it returns non-zero, fix before proceeding.
+
+## Prerequisites
+
+```bash
+# 1. dexbotic checkout + venv
+cd /path/to/dexbotic
+source ACTIVATE_DEXBOTIC.sh
+pip install "deepspeed==0.14.4"  # version-pinned for torch 2.2 compat
+
+# 2. Standard proxy/env (your network)
+source /etc/profile.d/proxy.sh   # or equivalent
+export HF_ENDPOINT=https://hf-mirror.com  # optional but often faster
+
+# 3. Pick a data root with ≥60 GB free
+export DM0_VL_ROOT=/data/dm0_vl_midtrain_50gb
+mkdir -p "$DM0_VL_ROOT"
+```
+
+## Step 1 — Dry-run sanity check
+
+```bash
+python midtrain_vl_50gb/tools/prepare.py --dry-run
+```
+
+Expected: prints 4 sources with their target sizes. Shouldn't touch network.
+
+## Step 2 — Pilot run on a single source (5 GB)
+
+```bash
+python midtrain_vl_50gb/tools/prepare.py --source cambrian737k --target-bytes 5G
+```
+
+Expected:
+- `progress/cambrian737k.json` populated
+- `annotations/cambrian737k/episode_*.jsonl` (≥ 1 file, 10000 rows each)
+- `images/cambrian737k/*.jpg` ≈ 5 GB
+- exit code 0
+
+If it stalls on COCO 429s, that's normal; the collector retries with exponential backoff. Resume with the same command.
+
+## Step 3 — Full collection (all 4 sources)
+
+```bash
+python midtrain_vl_50gb/tools/prepare.py
+```
+
+Expected runtime: 3-12 hours depending on proxy throughput. Auto-resumes if interrupted; safe to Ctrl-C and re-run. Final state:
+- `cambrian737k`: ~12 GB (target=12)
+- `cambrian10m_filtered`: ~9-11 GB (source-limited by COCO pool dedupe)
+- `llava_onevision`: ~22 GB across 30 subsets
+- `self_collected_proxy`: ~8 GB across 4 subsets
+
+`manifest.json` written to `$DM0_VL_ROOT`.
+
+## Step 4 — Hybrid resume rebuild (if you need to update progress.json)
+
+If you change collector code mid-run, use this before continuing:
+
+```bash
+python midtrain_vl_50gb/tools/reconcile_progress.py --dry-run
+python midtrain_vl_50gb/tools/reconcile_progress.py
+```
+
+Rebuilds `rows / image_bytes / seen_image_keys / subset_bytes_record` from on-disk facts. For `self_collected_proxy`, applies `synthdog → synthdog_en` and `cord → cord_v2` aliasing.
+
+## Step 5 — Index cache pre-compute
+
+```bash
+python midtrain_vl_50gb/tools/precompute_index_cache.py
+```
+
+Speeds up dexbotic `DexDataset` cold start by 30-60s.
+
+## Step 6 — Subset-coverage strict gate
+
+```bash
+python midtrain_vl_50gb/tools/subset_coverage_check.py --strict
+```
+
+Expected output:
+```
+[coverage] cambrian737k: OK
+[coverage] cambrian10m_filtered: OK
+[coverage] llava_onevision: OK
+[coverage] self_collected_proxy: OK
+```
+
+Exit 0. Specifically validates `self_collected_proxy.embspatial >= 50 MB` (the failure mode where total bytes hit target but a critical subset was empty).
+
+## Step 7 — DexDataset / DataCollator smoke test
+
+```bash
+export DEXBOTIC_DATA_PATH=$(realpath dexbotic/data/data_source)
+python midtrain_vl_50gb/tools/test_dataloader.py --batch-size 4
+```
+
+Expected: dataset_len ≈ 515,000, batch keys `{input_ids, labels, attention_mask, images}`. Exit 0.
+
+## Step 8 — Random-sample verification (8192 PIL.open)
+
+```bash
+python midtrain_vl_50gb/tools/verify_dataset.py --num-samples 2048
+```
+
+Expected:
+```json
+{
+  "total": 8192,
+  "failed": 0,
+  "by_status": {"ok": 8192},
+  "empty_sources": []
+}
+```
+
+## Step 9 — Throughput benchmark (optional)
+
+```python
+import os, time, torch
+from torch.utils.data import DataLoader
+from easydict import EasyDict
+
+os.environ["DEXBOTIC_DATA_PATH"] = os.environ["DM0_VL_ROOT"] + "/data_source"
+import dexbotic.data.data_source
+from dexbotic.data.collator import DataCollatorForSupervisedDataset
+from dexbotic.data.dataset.dex_dataset import DexDataset
+from dexbotic.data.dataset.rgb_preprocess import DummyRGBProcessor
+from dexbotic.data.dataset.tokenization import DummyTokenization
+from dexbotic.data.dataset.transform.common import Pipeline, ToDict, ToList, ToNumpy
+from dexbotic.data.dataset.transform.multimodal import LoadMultiModal
+
+
+class TinyTok:
+    pad_token_id = 0; eos_token_id = 1; model_max_length = 32
+
+
+ds = DexDataset(
+    data_args=EasyDict(
+        dataset_name="dm0vlmid_cambrian737k+dm0vlmid_cambrian10m_filtered+"
+                      "dm0vlmid_llava_onevision+dm0vlmid_self_collected_proxy",
+        num_images=1, data_keys=["input_ids", "labels", "image"],
+        images_keys=None, depths_keys=None, load_depth=False,
+        discrete_state_input=False, aug_policy=None, image_aspect_ratio=None,
+    ),
+    tokenization_func=DummyTokenization(),
+    action_process_func=Pipeline([ToDict(), ToNumpy(), LoadMultiModal(), ToList()]),
+    image_process_func=DummyRGBProcessor(),
+    depth_process_func=lambda _: torch.zeros(1),
+)
+loader = DataLoader(ds, batch_size=32, shuffle=True, num_workers=16,
+                    collate_fn=DataCollatorForSupervisedDataset(TinyTok()))
+it = iter(loader)
+for _ in range(5): next(it)  # warm
+t0 = time.time(); cnt = 0
+for _ in range(30): cnt += next(it)["input_ids"].shape[0]
+print(f"{cnt/(time.time()-t0):.1f} samples/s")
+```
+
+Expected: ≥ 50 samples/s on a server with NVMe disk and 16 CPU workers (we measured 69.7 samples/s on H200 box).
+
+## Step 10 — Unit tests
+
+```bash
+pytest midtrain_vl_50gb/tests/ -v
+```
+
+Expected: all tests in `test_collector_base.py`, `test_reconcile.py`, `test_subset_coverage.py` pass.
+
+## Step 11 — DM0 mid-train warmup (optional, requires mixed data)
+
+```bash
+export DM0_BASE_CKPT=./checkpoints/DM0-base
+mkdir -p checkpoints
+huggingface-cli download Dexmal/DM0-base --local-dir checkpoints/DM0-base
+
+# Edit warmup_dm0_vlonly.py: append a robot source to dataset_name, e.g.:
+#   "dm0vlmid_*+libero_goal+libero_object+libero_spatial"
+# Then download libero data per dexbotic README.
+
+WANDB_DISABLED=true torchrun --nproc_per_node=8 \
+  midtrain_vl_50gb/tools/warmup_dm0_vlonly.py
+```
+
+See `docs/06_warmup_findings.md` for the design constraint that DM0 dual-expert architecture requires actions tensor and therefore mixed VL+robot data for any forward pass.
+
+## Failure recovery
+
+| Symptom | Action |
+|---------|--------|
+| `set -u` `${PYTHONPATH}: unbound` | use `${PYTHONPATH:-}` in your shell init |
+| `ImportError: deepspeed not available` | `pip install deepspeed==0.14.4` (newer versions break torch 2.2) |
+| `module 'torch.library' has no attribute 'custom_op'` | downgrade deepspeed; never above 0.14.x for torch 2.2 |
+| `[stream] reconnect at offset=…` repeatedly | proxy is throttling; wait or switch `HF_ENDPOINT=https://hf-mirror.com` |
+| `[scp/embspatial] hf_hub_download failed` | network; embspatial metadata file is 250 MB, retry or use the mirror |
+| `coverage: FAIL: self_collected_proxy.embspatial …` | run `prepare.py --source self_collected_proxy --target-bytes 9G` to force re-collect |
+| `AttributeError: 'NoneType' object has no attribute 'shape'` in DM0 forward | VL-only data alone can't drive DM0; mix in a robot source (see Step 11) |
+
+## Reference: validated state
+
+Validated on 8 × NVIDIA H200 + dexbotic main:
+- 50.55 GB images / 515,572 rows / 35 jsonl shards
+- 4 sources registered as `dm0vlmid_{cambrian737k,cambrian10m_filtered,llava_onevision,self_collected_proxy}`
+- Strict coverage gate passes; verify 8192/8192 OK
+- DexDataset constructs in <30 s with pre-computed `index_cache.json`
+- Throughput 69.7 samples/s with bs=32 nw=16 dummy processors

--- a/midtrain_vl_50gb/tests/test_collector_base.py
+++ b/midtrain_vl_50gb/tests/test_collector_base.py
@@ -1,0 +1,80 @@
+# Unit tests for DurableEpisodeWriter resume / next_episode / pending-seen guard.
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1] / "tools"
+sys.path.insert(0, str(ROOT))
+from _collector_base import DurableEpisodeWriter, coco_url, normalize_conversations
+
+
+def _make_row(i):
+    return {
+        "images_1": {"type": "image", "url": f"src/{i:06d}.jpg"},
+        "conversations": [{"from": "human", "value": "<image>\nQ"}, {"from": "gpt", "value": "A"}],
+        "is_robot": False,
+    }
+
+
+def test_flush_writes_atomic_episode(tmp_path):
+    writer = DurableEpisodeWriter(tmp_path / "ann", tmp_path / ".prog/src.json", "src", episode_batch_size=3)
+    for i in range(3):
+        writer.add(_make_row(i), 1024, {"id": i}, f"img_{i}.jpg")
+    out = writer.flush()
+    assert out.name == "episode_000000.jsonl"
+    assert writer.flushed_rows == 3
+    assert writer.flushed_bytes == 3072
+    progress = json.loads((tmp_path / ".prog/src.json").read_text())
+    assert progress["rows"] == 3
+    assert progress["next_episode"] == 1
+
+
+def test_resume_picks_up_flushed_state(tmp_path):
+    w1 = DurableEpisodeWriter(tmp_path / "ann", tmp_path / ".prog/src.json", "src", episode_batch_size=2)
+    for i in range(2):
+        w1.add(_make_row(i), 100, {"id": i}, f"k_{i}")
+    w1.flush()
+    w1.final_save()
+
+    w2 = DurableEpisodeWriter(tmp_path / "ann", tmp_path / ".prog/src.json", "src", episode_batch_size=2)
+    assert w2.flushed_rows == 2
+    assert w2.flushed_bytes == 200
+    assert "k_0" in w2.seen_keys
+
+
+def test_pending_seen_keys_dedup(tmp_path):
+    w = DurableEpisodeWriter(tmp_path / "ann", tmp_path / ".prog/src.json", "src", episode_batch_size=10)
+    w.add(_make_row(0), 100, {}, "img_a")
+    w.add(_make_row(1), 100, {}, "img_a")  # duplicate within pending — should be dropped
+    assert len(w._pending_rows) == 1
+
+
+def test_next_episode_max_existing(tmp_path):
+    ann = tmp_path / "ann"
+    ann.mkdir()
+    (ann / "episode_000000.jsonl").write_text("{}\n")
+    (ann / "episode_000005.jsonl").write_text("{}\n")
+    w = DurableEpisodeWriter(ann, tmp_path / ".prog/src.json", "src", episode_batch_size=10)
+    assert w._next_episode == 6
+
+
+def test_normalize_conversations_injects_image_token():
+    result = normalize_conversations([
+        {"from": "human", "value": "What is in the image?"},
+        {"from": "gpt", "value": "A bus."},
+    ])
+    assert "<image>" in result[0]["value"]
+
+
+def test_coco_url_parses_train_val():
+    assert coco_url("coco/train2017/000000033471.jpg") == "https://images.cocodataset.org/train2017/000000033471.jpg"
+    assert coco_url("coco/val2017/000000000139.jpg") == "https://images.cocodataset.org/val2017/000000000139.jpg"
+    assert coco_url("coco/train2014/COCO_train2014_000000033471.jpg") == "https://images.cocodataset.org/train2014/000000033471.jpg"
+    assert coco_url("non/coco/path.jpg") is None
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/midtrain_vl_50gb/tests/test_reconcile.py
+++ b/midtrain_vl_50gb/tests/test_reconcile.py
@@ -1,0 +1,98 @@
+# Unit tests for reconcile_progress alias canonicalisation + on-disk rebuild.
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1] / "tools"
+sys.path.insert(0, str(ROOT))
+
+
+def test_scp_subset_alias_canonicalisation(tmp_path, monkeypatch):
+    """synthdog/cord directory names should map to canonical synthdog_en/cord_v2."""
+    os.environ["DM0_VL_ROOT"] = str(tmp_path)
+    # Re-import so recipe picks up the new ROOT
+    if "recipe" in sys.modules:
+        del sys.modules["recipe"]
+    if "reconcile_progress" in sys.modules:
+        del sys.modules["reconcile_progress"]
+    import recipe
+    import reconcile_progress
+
+    ann = recipe.ANNOTATIONS_DIR / "self_collected_proxy"
+    img = recipe.IMAGES_DIR / "self_collected_proxy"
+    ann.mkdir(parents=True)
+    (img / "uground").mkdir(parents=True)
+    (img / "embspatial").mkdir(parents=True)
+    (img / "synthdog").mkdir(parents=True)
+    (img / "cord").mkdir(parents=True)
+    recipe.PROGRESS_DIR.mkdir(parents=True, exist_ok=True)
+
+    img_data = b"x" * 2048
+
+    def write_record(subdir, idx):
+        rel = f"self_collected_proxy/{subdir}/{idx:06d}.jpg"
+        (recipe.IMAGES_DIR / rel).write_bytes(img_data)
+        return {"images_1": {"type": "image", "url": rel}, "conversations": [], "is_robot": False}
+
+    with (ann / "episode_000000.jsonl").open("w") as f:
+        for i in range(3):
+            f.write(json.dumps(write_record("uground", i)) + "\n")
+            f.write(json.dumps(write_record("embspatial", i)) + "\n")
+            f.write(json.dumps(write_record("synthdog", i)) + "\n")
+            f.write(json.dumps(write_record("cord", i)) + "\n")
+
+    new_progress = reconcile_progress.reconcile_one("self_collected_proxy")
+    assert new_progress is not None
+    rec = new_progress["subset_bytes_record"]
+
+    # Aliases applied
+    assert "synthdog_en" in rec
+    assert "cord_v2" in rec
+    assert "synthdog" not in rec
+    assert "cord" not in rec
+    # No alias for these
+    assert "uground" in rec
+    assert "embspatial" in rec
+    # Each subdir wrote 3 × 2048 bytes
+    assert rec["uground"] == 6144
+    assert rec["synthdog_en"] == 6144
+
+    assert new_progress["rows"] == 12
+    assert new_progress["progress_version"] == 2
+
+
+def test_reconcile_drops_legacy_extra_for_scp(tmp_path):
+    os.environ["DM0_VL_ROOT"] = str(tmp_path)
+    for mod in ("recipe", "reconcile_progress"):
+        if mod in sys.modules:
+            del sys.modules[mod]
+    import recipe
+    import reconcile_progress
+
+    (recipe.ANNOTATIONS_DIR / "self_collected_proxy").mkdir(parents=True)
+    recipe.PROGRESS_DIR.mkdir(parents=True, exist_ok=True)
+    progress_path = recipe.PROGRESS_DIR / "self_collected_proxy.json"
+    progress_path.write_text(json.dumps({
+        "rows": 1234,
+        "image_bytes": 5000,
+        "next_episode": 0,
+        "seen_image_keys": [],
+        "completed_subsets": ["uground", "embspatial"],
+        "subset_offsets": {"uground": 999},
+        "subset_bytes_record": {"uground": 9999999},
+    }))
+
+    new_progress = reconcile_progress.reconcile_one("self_collected_proxy")
+    # SCP forces reset of completed_subsets / subset_offsets / old subset_bytes_record
+    assert "completed_subsets" not in new_progress
+    assert "subset_offsets" not in new_progress
+    # rows/bytes are recalculated (empty annotations dir → 0)
+    assert new_progress["rows"] == 0
+    assert new_progress["image_bytes"] == 0
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/midtrain_vl_50gb/tests/test_subset_coverage.py
+++ b/midtrain_vl_50gb/tests/test_subset_coverage.py
@@ -1,0 +1,94 @@
+# Unit tests for subset_coverage_check thresholds.
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1] / "tools"
+sys.path.insert(0, str(ROOT))
+
+
+def _setup_progress(tmp_path, source, payload):
+    os.environ["DM0_VL_ROOT"] = str(tmp_path)
+    for mod in ("recipe", "subset_coverage_check"):
+        if mod in sys.modules:
+            del sys.modules[mod]
+    import recipe
+    recipe.PROGRESS_DIR.mkdir(parents=True, exist_ok=True)
+    (recipe.PROGRESS_DIR / f"{source}.json").write_text(json.dumps(payload))
+
+
+def test_scp_pass_when_all_subsets_meet_min(tmp_path):
+    _setup_progress(tmp_path, "self_collected_proxy", {
+        "rows": 100,
+        "image_bytes": 8 * 1024**3,
+        "next_episode": 1,
+        "seen_image_keys": [],
+        "subset_bytes_record": {
+            "uground": 600 * 1024**2,
+            "embspatial": 100 * 1024**2,
+            "synthdog_en": 200 * 1024**2,
+            "cord_v2": 20 * 1024**2,
+        },
+    })
+    import subset_coverage_check
+    ok, fails = subset_coverage_check.check_source_coverage("self_collected_proxy")
+    assert ok, f"unexpected failures: {fails}"
+
+
+def test_scp_fail_when_embspatial_below_min(tmp_path):
+    _setup_progress(tmp_path, "self_collected_proxy", {
+        "rows": 100,
+        "image_bytes": 8 * 1024**3,
+        "next_episode": 1,
+        "seen_image_keys": [],
+        "subset_bytes_record": {
+            "uground": 600 * 1024**2,
+            "embspatial": 10 * 1024**2,  # below 50 MB threshold
+            "synthdog_en": 200 * 1024**2,
+            "cord_v2": 20 * 1024**2,
+        },
+    })
+    import subset_coverage_check
+    ok, fails = subset_coverage_check.check_source_coverage("self_collected_proxy")
+    assert not ok
+    assert any("embspatial" in f for f in fails)
+
+
+def test_llava_pass_when_5_subsets_above_per_min(tmp_path):
+    _setup_progress(tmp_path, "llava_onevision", {
+        "rows": 1000,
+        "image_bytes": 5 * 1024**3,
+        "next_episode": 1,
+        "seen_image_keys": [],
+        "subset_bytes_record": {f"sub_{i}": 200 * 1024**2 for i in range(5)},
+    })
+    import subset_coverage_check
+    ok, fails = subset_coverage_check.check_source_coverage("llava_onevision")
+    assert ok, f"unexpected failures: {fails}"
+
+
+def test_llava_fail_when_only_3_subsets_above_per_min(tmp_path):
+    _setup_progress(tmp_path, "llava_onevision", {
+        "rows": 1000,
+        "image_bytes": 5 * 1024**3,
+        "next_episode": 1,
+        "seen_image_keys": [],
+        "subset_bytes_record": {
+            "sub_0": 200 * 1024**2,
+            "sub_1": 200 * 1024**2,
+            "sub_2": 200 * 1024**2,
+            "sub_3": 50 * 1024**2,  # below per-subset min
+            "sub_4": 50 * 1024**2,
+        },
+    })
+    import subset_coverage_check
+    ok, fails = subset_coverage_check.check_source_coverage("llava_onevision")
+    assert not ok
+    assert any("3 subsets" in f or "need 5" in f for f in fails)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/midtrain_vl_50gb/tools/_collector_base.py
+++ b/midtrain_vl_50gb/tools/_collector_base.py
@@ -1,0 +1,298 @@
+# Shared utilities for all source collectors.
+# - DurableEpisodeWriter: progress.json mirrors only flushed-to-disk state.
+# - stream_jsonl: range-resumable JSONL streaming with proxy-aware reconnect.
+# - download_coco_record: the COCO image fetcher reused by Cambrian collectors.
+# - normalize_conversations: enforce dexbotic Dexdata conversation format.
+import io
+import json
+import os
+import random
+import re
+import ssl
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from PIL import Image
+
+SSL_CTX = ssl._create_unverified_context()
+MIN_IMAGE_BYTES = 1024
+MAX_IMAGE_BYTES = 10 * 1024 * 1024
+HTTP_RETRIES = 3
+HTTP_BACKOFF_BASE = 2.0
+HTTP_BACKOFF_MAX = 30.0
+DOWNLOAD_TIMEOUT = 60
+
+COCO_BASE = "https://images.cocodataset.org"
+COCO_RE = re.compile(r"^coco/(train|val)(201[47])/(?:COCO_(?:train|val)201[47]_)?(\d{12})\.jpg$")
+
+
+@dataclass
+class CollectorReport:
+    source: str = ""
+    rows: int = 0
+    image_bytes: int = 0
+    jsonl_files: list = field(default_factory=list)
+    skipped: dict = field(default_factory=dict)
+    items_meta: list = field(default_factory=list)
+
+
+def normalize_conversations(conversations):
+    """Coerce arbitrary conversation lists to dexbotic Dexdata `[{"from": ..., "value": ...}]`,
+    inject `<image>` token into the first human turn if missing."""
+    if not isinstance(conversations, list):
+        return [
+            {"from": "human", "value": "<image>\nDescribe the image."},
+            {"from": "gpt", "value": str(conversations)},
+        ]
+    norm = []
+    for turn in conversations:
+        if not isinstance(turn, dict):
+            continue
+        role = str(turn.get("from") or turn.get("role") or "human")
+        if role == "user":
+            role = "human"
+        elif role == "assistant":
+            role = "gpt"
+        value = turn.get("value") or turn.get("content") or turn.get("text") or ""
+        norm.append({"from": role, "value": str(value)})
+    if not norm:
+        return [
+            {"from": "human", "value": "<image>\nDescribe the image."},
+            {"from": "gpt", "value": "No answer."},
+        ]
+    first_human = next((t for t in norm if t["from"] == "human"), norm[0])
+    if "<image>" not in first_human["value"]:
+        first_human["value"] = "<image>\n" + first_human["value"]
+    return norm
+
+
+def http_fetch(url, timeout=DOWNLOAD_TIMEOUT):
+    last_exc = None
+    for attempt in range(HTTP_RETRIES):
+        try:
+            with urllib.request.urlopen(url, timeout=timeout, context=SSL_CTX) as resp:
+                return resp.read()
+        except (urllib.error.URLError, urllib.error.HTTPError, ConnectionError, TimeoutError) as e:
+            last_exc = e
+            wait = min(HTTP_BACKOFF_BASE * (2 ** attempt), HTTP_BACKOFF_MAX)
+            time.sleep(wait + random.uniform(0, 1))
+    raise RuntimeError(f"http_failed: {url}: {last_exc}")
+
+
+def validate_image(data):
+    try:
+        Image.open(io.BytesIO(data)).verify()
+    except Exception:
+        return False
+    return True
+
+
+def coco_url(image_path):
+    """Map a Dexdata image_path like 'coco/train2017/<id>.jpg' to the COCO CDN URL."""
+    m = COCO_RE.match(image_path)
+    if not m:
+        return None
+    split, year, image_id = m.groups()
+    return f"{COCO_BASE}/{split}{year}/{image_id}.jpg"
+
+
+def download_coco_record(record, images_dir, source_name, seen_keys):
+    """Shared COCO downloader for Cambrian-* collectors.
+    Returns ((record, local_rel, size, image_path), status) or (None, status)."""
+    image_path = str(record.get("image", ""))
+    url = coco_url(image_path)
+    if not url:
+        return None, "invalid_path"
+    image_name = Path(image_path).name
+    if image_name in seen_keys:
+        return None, "already_present"
+    local_rel = f"{source_name}/{image_name}"
+    local_path = images_dir / local_rel
+    if local_path.exists() and local_path.stat().st_size >= MIN_IMAGE_BYTES:
+        return (record, local_rel, local_path.stat().st_size, image_path), "ok_cached"
+    try:
+        data = http_fetch(url)
+    except Exception:
+        return None, "http_failed"
+    if len(data) > MAX_IMAGE_BYTES:
+        return None, "too_large"
+    if len(data) < MIN_IMAGE_BYTES:
+        return None, "too_small"
+    if not validate_image(data):
+        return None, "pil_error"
+    local_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = local_path.with_suffix(local_path.suffix + ".tmp")
+    tmp.write_bytes(data)
+    tmp.replace(local_path)
+    return (record, local_rel, len(data), image_path), "ok"
+
+
+class DurableEpisodeWriter:
+    """Buffer rows in memory; on flush, fsync + atomic rename a new episode_*.jsonl,
+    then update flushed counts and persist progress.json. Crashes only lose unflushed
+    in-memory rows; never corrupt on-disk jsonl. Resume reuses progress.json.
+    """
+
+    def __init__(self, annotations_dir, progress_path, source_name, episode_batch_size=10000):
+        self.annotations_dir = Path(annotations_dir)
+        self.progress_path = Path(progress_path)
+        self.source = source_name
+        self.batch_size = episode_batch_size
+        self.annotations_dir.mkdir(parents=True, exist_ok=True)
+        self.progress_path.parent.mkdir(parents=True, exist_ok=True)
+
+        self._pending_rows = []
+        self._pending_bytes = 0
+        self._pending_meta = []
+        self._pending_seen_keys = []
+        self._reserved_seen_keys = set()
+        self._extra_progress = {}
+        self._pending_meta_history = []
+
+        self._existing_episodes = sorted(self.annotations_dir.glob("episode_*.jsonl"))
+        self._progress = self._load_progress()
+        self._next_episode = max(
+            int(self._progress.get("next_episode", 0)),
+            len(self._existing_episodes),
+        )
+        self.flushed_rows = int(self._progress.get("rows", 0))
+        self.flushed_bytes = int(self._progress.get("image_bytes", 0))
+        self.seen_keys = set(self._progress.get("seen_image_keys", []))
+
+    def _load_progress(self):
+        if not self.progress_path.exists():
+            return {}
+        try:
+            return json.loads(self.progress_path.read_text())
+        except Exception:
+            return {}
+
+    def get_extra(self, key, default=None):
+        return self._progress.get(key, default)
+
+    def add(self, row, byte_size, meta, seen_key):
+        if seen_key is not None:
+            if seen_key in self.seen_keys or seen_key in self._reserved_seen_keys:
+                return self.flushed_bytes + self._pending_bytes
+            self._reserved_seen_keys.add(seen_key)
+            self._pending_seen_keys.append(seen_key)
+        self._pending_rows.append(row)
+        self._pending_bytes += byte_size
+        self._pending_meta.append(meta)
+        return self.flushed_bytes + self._pending_bytes
+
+    @property
+    def total_bytes(self):
+        return self.flushed_bytes + self._pending_bytes
+
+    @property
+    def total_rows(self):
+        return self.flushed_rows + len(self._pending_rows)
+
+    @property
+    def jsonl_files(self):
+        return [str(p) for p in self._existing_episodes]
+
+    def should_flush(self):
+        return len(self._pending_rows) >= self.batch_size
+
+    def flush(self, set_extra=None):
+        if not self._pending_rows:
+            return None
+        if set_extra:
+            self._extra_progress.update(set_extra)
+        out = self.annotations_dir / f"episode_{self._next_episode:06d}.jsonl"
+        while out.exists():
+            self._next_episode += 1
+            out = self.annotations_dir / f"episode_{self._next_episode:06d}.jsonl"
+        tmp = out.with_suffix(".jsonl.tmp")
+        with tmp.open("w", encoding="utf-8") as fh:
+            for r in self._pending_rows:
+                fh.write(json.dumps(r, ensure_ascii=False) + "\n")
+            fh.flush()
+            os.fsync(fh.fileno())
+        tmp.replace(out)
+        self._existing_episodes.append(out)
+        flushed_count = len(self._pending_rows)
+        flushed_size = self._pending_bytes
+        flushed_meta = list(self._pending_meta)
+        flushed_seen = list(self._pending_seen_keys)
+        self._pending_rows.clear()
+        self._pending_bytes = 0
+        self._pending_meta.clear()
+        self._pending_seen_keys.clear()
+        self._reserved_seen_keys.clear()
+        self.flushed_rows += flushed_count
+        self.flushed_bytes += flushed_size
+        for k in flushed_seen:
+            self.seen_keys.add(k)
+        self._next_episode += 1
+        self._pending_meta_history.extend(flushed_meta)
+        self._save_progress()
+        return out
+
+    def update_extra(self, **kwargs):
+        self._extra_progress.update(kwargs)
+
+    def _save_progress(self):
+        payload = {
+            "rows": self.flushed_rows,
+            "image_bytes": self.flushed_bytes,
+            "next_episode": self._next_episode,
+            "seen_image_keys": list(self.seen_keys),
+        }
+        payload.update(self._extra_progress)
+        tmp = self.progress_path.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(payload, ensure_ascii=False))
+        tmp.replace(self.progress_path)
+
+    def final_save(self, **extra):
+        # Pending rows are intentionally NOT flushed here; they would already be flushed
+        # if the run completed normally via flush(). final_save persists extra metadata only.
+        if extra:
+            self._extra_progress.update(extra)
+        self._save_progress()
+
+
+def stream_jsonl(url, start_offset=0, max_retries=20, line_max_bytes=4 * 1024 * 1024):
+    """Stream a remote JSONL with byte-offset Range resume on transient SSL/EOF errors."""
+    consumed = start_offset
+    for retry in range(max_retries):
+        buf = b""
+        try:
+            headers = {"Range": f"bytes={consumed}-"} if consumed else {}
+            req = urllib.request.Request(url, headers=headers)
+            with urllib.request.urlopen(req, timeout=180, context=SSL_CTX) as resp:
+                got_data = False
+                for chunk in iter(lambda: resp.read(1024 * 1024), b""):
+                    if chunk:
+                        got_data = True
+                    buf += chunk
+                    while b"\n" in buf:
+                        line, buf = buf.split(b"\n", 1)
+                        consumed += len(line) + 1
+                        if not line.strip():
+                            continue
+                        try:
+                            yield json.loads(line.decode("utf-8")), consumed
+                        except Exception:
+                            continue
+                if not got_data and retry > 0:
+                    return
+            try:
+                head_req = urllib.request.Request(url, method="HEAD")
+                with urllib.request.urlopen(head_req, timeout=30, context=SSL_CTX) as hr:
+                    total = int(hr.headers.get("X-Linked-Size") or hr.headers.get("Content-Length") or 0)
+                if total and consumed >= total - line_max_bytes:
+                    return
+            except Exception as e:
+                print(f"[stream] head check failed: {e}", flush=True)
+            print(f"[stream] reconnect at offset={consumed} retry={retry+1}/{max_retries}", flush=True)
+            time.sleep(min(5 + retry, 30))
+        except Exception as e:
+            print(f"[stream] error at offset={consumed}: {e}, retry {retry+1}", flush=True)
+            time.sleep(min(5 + retry, 30))
+    print(f"[stream] gave up after {max_retries} retries at offset={consumed}", flush=True)

--- a/midtrain_vl_50gb/tools/collectors/cambrian10m_filtered.py
+++ b/midtrain_vl_50gb/tools/collectors/cambrian10m_filtered.py
@@ -1,0 +1,195 @@
+# Cambrian-10M filtered: streaming JSONL with paper §3.2 quality filters.
+# Removes math-heavy, non-English, writing-centric content; dedupes COCO images
+# already pulled by cambrian737k.
+import json
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+THIS_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(THIS_DIR.parent))
+from _collector_base import (
+    CollectorReport,
+    DurableEpisodeWriter,
+    coco_url,
+    download_coco_record,
+    normalize_conversations,
+    stream_jsonl,
+)
+from disk_guard import DiskFuse
+
+REPO = "nyu-visionx/Cambrian-10M"
+JSONL_URL = (
+    "https://huggingface.co/datasets/nyu-visionx/Cambrian-10M/"
+    "resolve/main/jsons/Cambrian10M.jsonl"
+)
+SOURCE_NAME = "cambrian10m_filtered"
+DOWNLOAD_BATCH = 256
+
+MIN_TEXT_LEN = 50
+MAX_TEXT_LEN = 6000
+MIN_ASCII_RATIO = 0.7
+
+BANNED_KEYWORDS = [
+    "solve", "equation", "proof", "calculate", "derive", "integrate", "differentiate",
+    "write an essay", "write a poem", "poem", "sonnet", "haiku", "novel",
+    "translate to", "translate from", "translate the",
+    "latex", "formula", "theorem", "lemma", "matrix", "polynomial",
+    "中文", "日本語", "한국어", "français", "español", "deutsch", "русский",
+    "代码", "算法", "函数",
+]
+
+
+def _filter_keep(obj):
+    if not obj.get("image"):
+        return False, "no_image"
+    if not coco_url(str(obj["image"])):
+        return False, "non_coco"
+    convs = obj.get("conversations") or []
+    if not convs:
+        return False, "no_conversations"
+    text = json.dumps(convs, ensure_ascii=False).lower()
+    n = len(text)
+    if n < MIN_TEXT_LEN:
+        return False, "too_short"
+    if n > MAX_TEXT_LEN:
+        return False, "too_long"
+    ascii_count = sum(1 for c in text if ord(c) < 128)
+    if ascii_count / n < MIN_ASCII_RATIO:
+        return False, "low_ascii"
+    for w in BANNED_KEYWORDS:
+        if w in text:
+            return False, "banned_keyword"
+    return True, "ok"
+
+
+def _load_cambrian737k_seen(progress_dir):
+    p = Path(progress_dir) / "cambrian737k.json"
+    if not p.exists():
+        return set()
+    try:
+        return set(json.loads(p.read_text()).get("seen_image_keys", []))
+    except Exception:
+        return set()
+
+
+def collect_at_scale(
+    target_image_bytes,
+    annotations_dir,
+    images_dir,
+    raw_dir,
+    progress_path,
+    episode_batch_size=10000,
+    disk_check_every=200,
+    disk_floor_gb=100,
+    seen_image_keys=None,
+):
+    annotations_dir = Path(annotations_dir)
+    images_dir = Path(images_dir)
+    progress_path = Path(progress_path)
+    (images_dir / SOURCE_NAME).mkdir(parents=True, exist_ok=True)
+
+    fuse = DiskFuse(annotations_dir, disk_floor_gb)
+    writer = DurableEpisodeWriter(annotations_dir, progress_path, SOURCE_NAME, episode_batch_size)
+    if seen_image_keys:
+        for k in seen_image_keys:
+            writer.seen_keys.add(k)
+    cambrian737k_seen = _load_cambrian737k_seen(progress_path.parent)
+    for k in cambrian737k_seen:
+        writer.seen_keys.add(k)
+    print(f"[cambrian10m] resume rows={writer.flushed_rows} bytes={writer.flushed_bytes/1024**3:.2f}GB "
+          f"dedupe seen={len(writer.seen_keys)} keys (incl {len(cambrian737k_seen)} from cambrian737k)", flush=True)
+
+    jsonl_offset = int(writer.get_extra("jsonl_offset", 0))
+
+    report = CollectorReport(source=SOURCE_NAME)
+    for k in ("no_image", "non_coco", "no_conversations", "too_short", "too_long",
+              "low_ascii", "banned_keyword", "invalid_path", "http_failed",
+              "too_small", "too_large", "pil_error", "already_present",
+              "ok_cached", "ok"):
+        report.skipped.setdefault(k, 0)
+
+    pending_candidates = []
+    images_since_check = 0
+    last_log = 0.0
+    line_count = 0
+    last_offset_save = jsonl_offset
+
+    print(f"[cambrian10m] streaming {JSONL_URL} from offset={jsonl_offset}", flush=True)
+
+    def _drain(candidates):
+        nonlocal images_since_check
+        if not candidates:
+            return
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            futures = {pool.submit(download_coco_record, r, images_dir, SOURCE_NAME, writer.seen_keys): r for r in candidates}
+            for fut in as_completed(futures):
+                if writer.total_bytes >= target_image_bytes:
+                    break
+                try:
+                    rec_result, status = fut.result()
+                except Exception:
+                    report.skipped["http_failed"] += 1
+                    continue
+                report.skipped[status] = report.skipped.get(status, 0) + 1
+                if status not in ("ok", "ok_cached"):
+                    continue
+                rec, local_rel, size, image_path = rec_result
+                conversations = rec.get("conversations") or []
+                row = {
+                    "images_1": {"type": "image", "url": local_rel},
+                    "conversations": normalize_conversations(conversations),
+                    "is_robot": False,
+                }
+                meta = {
+                    "source": SOURCE_NAME, "repo": REPO,
+                    "id": rec.get("id"), "image": image_path,
+                    "filter": "local_filter_v2", "dedupe_against": "cambrian737k",
+                }
+                writer.add(row, size, meta, Path(image_path).name)
+                images_since_check += 1
+                if images_since_check >= disk_check_every:
+                    fuse.check()
+                    images_since_check = 0
+                if writer.should_flush():
+                    out = writer.flush()
+                    if out:
+                        print(f"[cambrian10m] flushed {out.name} rows={writer.flushed_rows} bytes={writer.flushed_bytes/1024**3:.2f}GB", flush=True)
+
+    try:
+        for obj, byte_offset in stream_jsonl(JSONL_URL, start_offset=jsonl_offset):
+            line_count += 1
+            if writer.total_bytes >= target_image_bytes:
+                break
+            keep, reason = _filter_keep(obj)
+            if not keep:
+                report.skipped[reason] = report.skipped.get(reason, 0) + 1
+                continue
+            pending_candidates.append(obj)
+            if len(pending_candidates) >= DOWNLOAD_BATCH:
+                _drain(pending_candidates)
+                pending_candidates = []
+                writer.update_extra(jsonl_offset=byte_offset)
+                last_offset_save = byte_offset
+            if time.time() - last_log > 30:
+                print(f"[cambrian10m] scanned={line_count} pending={len(pending_candidates)} "
+                      f"rows={writer.flushed_rows} bytes={writer.flushed_bytes/1024**3:.2f}GB", flush=True)
+                last_log = time.time()
+    except Exception as e:
+        print(f"[cambrian10m] stream error: {e}, will rely on resume", flush=True)
+
+    if pending_candidates:
+        _drain(pending_candidates)
+    if writer._pending_rows:
+        out = writer.flush()
+        if out:
+            print(f"[cambrian10m] final flush {out.name} rows={writer.flushed_rows} bytes={writer.flushed_bytes/1024**3:.2f}GB", flush=True)
+    writer.final_save(jsonl_offset=last_offset_save)
+
+    report.rows = writer.flushed_rows
+    report.image_bytes = writer.flushed_bytes
+    report.jsonl_files = writer.jsonl_files
+    report.items_meta = writer._pending_meta_history
+    print(f"[cambrian10m] DONE rows={writer.flushed_rows} bytes={writer.flushed_bytes/1024**3:.2f}GB skipped={dict(report.skipped)}", flush=True)
+    return report

--- a/midtrain_vl_50gb/tools/collectors/cambrian737k.py
+++ b/midtrain_vl_50gb/tools/collectors/cambrian737k.py
@@ -1,0 +1,148 @@
+# Cambrian-737k: full COCO download with shuffle for diversity.
+# Paper §3.2 (1) — high-quality multi-turn VQA on COCO images.
+import json
+import random
+import sys
+import time
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+THIS_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(THIS_DIR.parent))
+from _collector_base import (
+    CollectorReport,
+    DurableEpisodeWriter,
+    SSL_CTX,
+    download_coco_record,
+    normalize_conversations,
+)
+from disk_guard import DiskFuse
+
+REPO = "LanguageBind/Cambrian737k"
+JSON_URL = (
+    "https://huggingface.co/datasets/LanguageBind/Cambrian737k/"
+    "resolve/main/Cambrian737k/Cambrian737k.json"
+)
+SOURCE_NAME = "cambrian737k"
+META_TIMEOUT = 1200
+META_MIN_BYTES = 1_000_000_000
+SHUFFLE_SEED = 20260425
+DOWNLOAD_BATCH = 256
+
+
+def _download_metadata(raw_dir):
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    dest = raw_dir / "Cambrian737k.json"
+    if dest.exists() and dest.stat().st_size >= META_MIN_BYTES:
+        return dest
+    tmp = dest.with_suffix(".json.tmp")
+    print(f"[cambrian737k] downloading meta JSON (~1.08GB) to {dest}", flush=True)
+    with urllib.request.urlopen(JSON_URL, timeout=META_TIMEOUT, context=SSL_CTX) as resp, tmp.open("wb") as fh:
+        chunk = 1024 * 1024
+        total = 0
+        last_log = time.time()
+        while True:
+            buf = resp.read(chunk)
+            if not buf:
+                break
+            fh.write(buf)
+            total += len(buf)
+            if time.time() - last_log > 5.0:
+                print(f"[cambrian737k]   meta {total/1024**3:.2f}GB", flush=True)
+                last_log = time.time()
+    tmp.replace(dest)
+    return dest
+
+
+def collect_at_scale(
+    target_image_bytes,
+    annotations_dir,
+    images_dir,
+    raw_dir,
+    progress_path,
+    episode_batch_size=10000,
+    disk_check_every=200,
+    disk_floor_gb=100,
+    seen_image_keys=None,
+):
+    annotations_dir = Path(annotations_dir)
+    images_dir = Path(images_dir)
+    raw_dir = Path(raw_dir)
+    (images_dir / SOURCE_NAME).mkdir(parents=True, exist_ok=True)
+
+    fuse = DiskFuse(annotations_dir, disk_floor_gb)
+    writer = DurableEpisodeWriter(annotations_dir, progress_path, SOURCE_NAME, episode_batch_size)
+    if seen_image_keys:
+        for k in seen_image_keys:
+            writer.seen_keys.add(k)
+    print(f"[cambrian737k] resume rows={writer.flushed_rows} bytes={writer.flushed_bytes/1024**3:.2f}GB", flush=True)
+
+    json_path = _download_metadata(raw_dir / SOURCE_NAME)
+    print(f"[cambrian737k] loading meta JSON ({json_path.stat().st_size/1024**3:.2f}GB)", flush=True)
+    t0 = time.time()
+    with json_path.open() as f:
+        records = json.load(f)
+    print(f"[cambrian737k] {len(records)} candidates, load took {time.time()-t0:.1f}s", flush=True)
+
+    rng = random.Random(SHUFFLE_SEED)
+    rng.shuffle(records)
+
+    report = CollectorReport(source=SOURCE_NAME)
+    for k in ("invalid_path", "http_failed", "too_small", "too_large", "pil_error",
+              "already_present", "no_conversations", "ok_cached", "ok"):
+        report.skipped.setdefault(k, 0)
+
+    images_since_check = 0
+    print(f"[cambrian737k] target={target_image_bytes/1024**3:.2f}GB current={writer.flushed_bytes/1024**3:.2f}GB", flush=True)
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        for batch_start in range(0, len(records), DOWNLOAD_BATCH):
+            if writer.total_bytes >= target_image_bytes:
+                break
+            batch = records[batch_start:batch_start + DOWNLOAD_BATCH]
+            futures = {pool.submit(download_coco_record, r, images_dir, SOURCE_NAME, writer.seen_keys): r for r in batch}
+            for fut in as_completed(futures):
+                if writer.total_bytes >= target_image_bytes:
+                    break
+                try:
+                    rec_result, status = fut.result()
+                except Exception:
+                    report.skipped["http_failed"] += 1
+                    continue
+                report.skipped[status] = report.skipped.get(status, 0) + 1
+                if status not in ("ok", "ok_cached"):
+                    continue
+                rec, local_rel, size, image_path = rec_result
+                conversations = rec.get("conversations") or []
+                if not conversations:
+                    report.skipped["no_conversations"] += 1
+                    continue
+                row = {
+                    "images_1": {"type": "image", "url": local_rel},
+                    "conversations": normalize_conversations(conversations),
+                    "is_robot": False,
+                }
+                meta = {"source": SOURCE_NAME, "repo": REPO, "id": rec.get("id"), "image": image_path}
+                writer.add(row, size, meta, Path(image_path).name)
+                images_since_check += 1
+                if images_since_check >= disk_check_every:
+                    fuse.check()
+                    images_since_check = 0
+                if writer.should_flush():
+                    out = writer.flush()
+                    if out:
+                        print(f"[cambrian737k] flushed {out.name} rows={writer.flushed_rows} bytes={writer.flushed_bytes/1024**3:.2f}GB", flush=True)
+
+    if writer._pending_rows:
+        out = writer.flush()
+        if out:
+            print(f"[cambrian737k] final flush {out.name} rows={writer.flushed_rows} bytes={writer.flushed_bytes/1024**3:.2f}GB", flush=True)
+    writer.final_save()
+
+    report.rows = writer.flushed_rows
+    report.image_bytes = writer.flushed_bytes
+    report.jsonl_files = writer.jsonl_files
+    report.items_meta = writer._pending_meta_history
+    print(f"[cambrian737k] DONE rows={writer.flushed_rows} bytes={writer.flushed_bytes/1024**3:.2f}GB skipped={dict(report.skipped)}", flush=True)
+    return report

--- a/midtrain_vl_50gb/tools/collectors/llava_onevision.py
+++ b/midtrain_vl_50gb/tools/collectors/llava_onevision.py
@@ -1,0 +1,218 @@
+# LLaVA-OneVision-Data multi-subset collector with dynamic per-subset quota.
+# Paper §3.2 (3) — broad multimodal understanding.
+import sys
+from pathlib import Path
+
+from datasets import load_dataset
+
+THIS_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(THIS_DIR.parent))
+from _collector_base import (
+    CollectorReport,
+    DurableEpisodeWriter,
+    MAX_IMAGE_BYTES,
+    MIN_IMAGE_BYTES,
+    normalize_conversations,
+)
+from disk_guard import DiskFuse
+from recipe import RECIPE
+try:
+    from subset_coverage_check import MIN_SUBSET_BYTES as _COVERAGE_MIN
+except Exception:
+    _COVERAGE_MIN = {}
+
+REPO = "lmms-lab/LLaVA-OneVision-Data"
+SOURCE_NAME = "llava_onevision"
+SUBSETS = RECIPE[SOURCE_NAME]["subsets"]
+MIN_PER_SUBSET_BYTES = 64 * 1024 * 1024
+
+
+def _safe_subset_dirname(name):
+    return name.replace("(", "_").replace(")", "_").replace(",", "_").replace(" ", "_")
+
+
+def _save_image(pil_image, dest_path):
+    dest_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dest_path.with_suffix(dest_path.suffix + ".tmp")
+    img = pil_image
+    if img.mode not in ("RGB", "L"):
+        img = img.convert("RGB")
+    img.save(tmp, format="JPEG", quality=92)
+    size = tmp.stat().st_size
+    if size < MIN_IMAGE_BYTES or size > MAX_IMAGE_BYTES:
+        tmp.unlink()
+        return None
+    tmp.replace(dest_path)
+    return size
+
+
+def collect_at_scale(
+    target_image_bytes,
+    annotations_dir,
+    images_dir,
+    raw_dir,
+    progress_path,
+    episode_batch_size=10000,
+    disk_check_every=200,
+    disk_floor_gb=100,
+    seen_image_keys=None,
+):
+    annotations_dir = Path(annotations_dir)
+    images_dir = Path(images_dir)
+    progress_path = Path(progress_path)
+    (images_dir / SOURCE_NAME).mkdir(parents=True, exist_ok=True)
+
+    fuse = DiskFuse(annotations_dir, disk_floor_gb)
+    writer = DurableEpisodeWriter(annotations_dir, progress_path, SOURCE_NAME, episode_batch_size)
+    print(f"[llava_ov] resume rows={writer.flushed_rows} bytes={writer.flushed_bytes/1024**3:.2f}GB", flush=True)
+
+    completed_subsets = set(writer.get_extra("completed_subsets", []))
+    subset_offsets = dict(writer.get_extra("subset_offsets", {}))
+    subset_bytes_record = dict(writer.get_extra("subset_bytes_record", {}))
+
+    def coverage_done():
+        cfg = _COVERAGE_MIN.get(SOURCE_NAME, {})
+        min_count = cfg.get("_min_subset_count", 0)
+        min_per = cfg.get("_min_per_subset_bytes", 0)
+        if min_count <= 0 or min_per <= 0:
+            return True
+        valid = sum(1 for s, b in subset_bytes_record.items() if not s.startswith("_") and b >= min_per)
+        return valid >= min_count
+
+    report = CollectorReport(source=SOURCE_NAME)
+    for k in ("no_image", "save_failed", "no_conversations", "ok", "subset_failed"):
+        report.skipped.setdefault(k, 0)
+
+    images_since_check = 0
+
+    for subset in SUBSETS:
+        if writer.total_bytes >= target_image_bytes and coverage_done():
+            print(f"[llava_ov] target reached and coverage satisfied, stop", flush=True)
+            break
+
+        # Skip-by-actual: if reconcile already counts enough bytes for this subset,
+        # don't re-stream. Avoids duplicate jsonl rows on hybrid resume.
+        subset_id = _safe_subset_dirname(subset)
+        actual_pre = subset_bytes_record.get(subset_id, 0)
+        progress_v = int(writer.get_extra("progress_version", 0))
+        cfg_min = _COVERAGE_MIN.get(SOURCE_NAME, {})
+        skip_threshold = cfg_min.get("_min_per_subset_bytes", 100 * 1024 * 1024)
+        if subset in completed_subsets:
+            print(f"[llava_ov] skip completed: {subset}", flush=True)
+            continue
+        if actual_pre >= skip_threshold and (progress_v >= 2 or writer.total_bytes >= target_image_bytes):
+            print(f"[llava_ov] skip {subset} (bytes={actual_pre/1024**2:.1f}MB >= {skip_threshold/1024**2:.0f}MB)", flush=True)
+            completed_subsets.add(subset)
+            writer.update_extra(
+                completed_subsets=list(completed_subsets),
+                subset_offsets=subset_offsets,
+                subset_bytes_record=subset_bytes_record,
+            )
+            continue
+
+        open_subsets = [s for s in SUBSETS if s not in completed_subsets]
+        remaining = max(0, target_image_bytes - writer.total_bytes)
+        per_subset_target = max(remaining // max(1, len(open_subsets)), MIN_PER_SUBSET_BYTES)
+
+        (images_dir / SOURCE_NAME / subset_id).mkdir(parents=True, exist_ok=True)
+        subset_start_bytes = writer.total_bytes
+        subset_skip_offset = int(subset_offsets.get(subset, 0))
+        print(f"[llava_ov] subset={subset} skip_offset={subset_skip_offset} per_subset={per_subset_target/1024**3:.2f}GB", flush=True)
+
+        try:
+            ds = load_dataset(REPO, subset, split="train", streaming=True)
+        except Exception as e:
+            print(f"[llava_ov] load_dataset failed for {subset}: {e}", flush=True)
+            report.skipped["subset_failed"] += 1
+            continue
+
+        idx = 0
+        last_committed_idx = subset_skip_offset
+        subset_exhausted = True
+        subset_failed = False
+        try:
+            for item in ds:
+                idx += 1
+                if idx <= subset_skip_offset:
+                    continue
+                if writer.total_bytes - subset_start_bytes >= per_subset_target:
+                    subset_exhausted = False
+                    break
+                if writer.total_bytes >= target_image_bytes:
+                    subset_exhausted = False
+                    break
+                image = item.get("image")
+                conversations = item.get("conversations") or []
+                if image is None:
+                    report.skipped["no_image"] += 1
+                    continue
+                if not conversations:
+                    report.skipped["no_conversations"] += 1
+                    continue
+                local_rel = f"{SOURCE_NAME}/{subset_id}/{idx:08d}.jpg"
+                local_path = images_dir / local_rel
+                if local_path.exists() and local_path.stat().st_size >= MIN_IMAGE_BYTES:
+                    size = local_path.stat().st_size
+                else:
+                    try:
+                        size = _save_image(image, local_path)
+                    except Exception:
+                        size = None
+                    if size is None:
+                        report.skipped["save_failed"] += 1
+                        continue
+                row = {
+                    "images_1": {"type": "image", "url": local_rel},
+                    "conversations": normalize_conversations(conversations),
+                    "is_robot": False,
+                }
+                meta = {"source": SOURCE_NAME, "repo": REPO, "subset": subset, "row": idx}
+                writer.add(row, size, meta, None)
+                subset_bytes_record[subset_id] = subset_bytes_record.get(subset_id, 0) + size
+                last_committed_idx = idx
+                report.skipped["ok"] += 1
+                images_since_check += 1
+                if images_since_check >= disk_check_every:
+                    fuse.check()
+                    images_since_check = 0
+                if writer.should_flush():
+                    subset_offsets[subset] = last_committed_idx
+                    writer.update_extra(
+                        completed_subsets=list(completed_subsets),
+                        subset_offsets=subset_offsets,
+                        subset_bytes_record=subset_bytes_record,
+                    )
+                    out = writer.flush()
+                    if out:
+                        print(f"[llava_ov] flushed {out.name} rows={writer.flushed_rows} bytes={writer.flushed_bytes/1024**3:.2f}GB", flush=True)
+        except Exception as e:
+            print(f"[llava_ov] subset {subset} stream error: {e}", flush=True)
+            subset_failed = True
+            subset_exhausted = False
+
+        subset_offsets[subset] = last_committed_idx
+        if not subset_failed and subset_exhausted:
+            completed_subsets.add(subset)
+        writer.update_extra(
+            completed_subsets=list(completed_subsets),
+            subset_offsets=subset_offsets,
+            subset_bytes_record=subset_bytes_record,
+        )
+
+    if writer._pending_rows:
+        out = writer.flush()
+        if out:
+            print(f"[llava_ov] final flush {out.name} rows={writer.flushed_rows} bytes={writer.flushed_bytes/1024**3:.2f}GB", flush=True)
+    writer.final_save(
+        completed_subsets=list(completed_subsets),
+        subset_offsets=subset_offsets,
+        subset_bytes_record=subset_bytes_record,
+    )
+
+    report.rows = writer.flushed_rows
+    report.image_bytes = writer.flushed_bytes
+    report.jsonl_files = writer.jsonl_files
+    report.items_meta = writer._pending_meta_history
+    print(f"[llava_ov] DONE rows={writer.flushed_rows} bytes={writer.flushed_bytes/1024**3:.2f}GB "
+          f"completed={len(completed_subsets)}/{len(SUBSETS)} skipped={dict(report.skipped)}", flush=True)
+    return report

--- a/midtrain_vl_50gb/tools/collectors/self_collected_proxy.py
+++ b/midtrain_vl_50gb/tools/collectors/self_collected_proxy.py
@@ -1,0 +1,413 @@
+# Self-collected multimodal: 4 subsets covering paper §3.2 (4) intent —
+# embodied-spatial QA, GUI grounding, OCR, and receipt/regions.
+# embspatial uses base64-encoded JPEG bytes (not file paths!) — see _collect_embspatial.
+import base64
+import io
+import json
+import sys
+import urllib.request
+from pathlib import Path
+
+from datasets import load_dataset
+from PIL import Image
+
+THIS_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(THIS_DIR.parent))
+from _collector_base import (
+    CollectorReport,
+    DurableEpisodeWriter,
+    MAX_IMAGE_BYTES,
+    MIN_IMAGE_BYTES,
+    SSL_CTX,
+    normalize_conversations,
+)
+from disk_guard import DiskFuse
+try:
+    from subset_coverage_check import MIN_SUBSET_BYTES as _COVERAGE_MIN
+except Exception:
+    _COVERAGE_MIN = {}
+
+SOURCE_NAME = "self_collected_proxy"
+HF_BASE = "https://huggingface.co/datasets"
+
+UGROUND_REPO = "zonghanHZH/UGround-V1-8k"
+EMBSPATIAL_REPO = "Phineas476/EmbSpatial-Bench"
+SYNTHDOG_REPO = "naver-clova-ix/synthdog-en"
+CORD_REPO = "naver-clova-ix/cord-v2"
+
+
+def _save_pil(pil_image, dest_path, fmt="JPEG"):
+    dest_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dest_path.with_suffix(dest_path.suffix + ".tmp")
+    img = pil_image
+    if img.mode not in ("RGB", "L"):
+        img = img.convert("RGB")
+    img.save(tmp, format=fmt, quality=92)
+    size = tmp.stat().st_size
+    if size < MIN_IMAGE_BYTES or size > MAX_IMAGE_BYTES:
+        tmp.unlink()
+        return None
+    tmp.replace(dest_path)
+    return size
+
+
+def _hf_url(repo, path):
+    return f"{HF_BASE}/{repo}/resolve/main/{urllib.request.pathname2url(path)}"
+
+
+def _http_get(url, timeout=120):
+    with urllib.request.urlopen(url, timeout=timeout, context=SSL_CTX) as resp:
+        return resp.read()
+
+
+def _collect_uground(images_dir, on_record, start_offset=0):
+    meta_url = _hf_url(UGROUND_REPO, "metadata/hf_train.json")
+    print(f"[scp/uground] fetching metadata: {meta_url}", flush=True)
+    items = json.loads(_http_get(meta_url).decode("utf-8"))
+    print(f"[scp/uground] {len(items)} items, start_offset={start_offset}", flush=True)
+    last_idx = start_offset
+    for idx, item in enumerate(items):
+        if idx < start_offset:
+            continue
+        last_idx = idx
+        elements = item.get("element") or []
+        if not elements:
+            continue
+        element = elements[0]
+        img_path = item.get("img_url")
+        if not img_path:
+            continue
+        try:
+            img_bytes = _http_get(_hf_url(UGROUND_REPO, f"images/{img_path}"))
+        except Exception:
+            continue
+        local_rel = f"{SOURCE_NAME}/uground/{Path(img_path).name}"
+        local_full = images_dir / local_rel
+        local_full.parent.mkdir(parents=True, exist_ok=True)
+        if local_full.exists() and local_full.stat().st_size >= MIN_IMAGE_BYTES:
+            size = local_full.stat().st_size
+        else:
+            try:
+                Image.open(io.BytesIO(img_bytes)).verify()
+                pil = Image.open(io.BytesIO(img_bytes))
+            except Exception:
+                continue
+            ext = local_full.suffix.lower()
+            fmt = "PNG" if ext == ".png" else "JPEG"
+            size = _save_pil(pil, local_full, fmt=fmt)
+            if size is None:
+                continue
+        point = element.get("point", [0, 0])
+        instruction = element.get("instruction", "the target element")
+        conversations = [
+            {"from": "human", "value": f"<image>\nLocate the GUI element: {instruction}"},
+            {"from": "gpt", "value": f"The target point is approximately [{point[0]:.1f}, {point[1]:.1f}]."},
+        ]
+        meta = {"source": SOURCE_NAME, "repo": UGROUND_REPO, "subset": "uground", "image": img_path, "row": idx}
+        if not on_record(local_rel, conversations, size, meta, idx):
+            return last_idx, False
+    return last_idx + 1, True
+
+
+def _collect_embspatial(images_dir, on_record, start_offset=0):
+    """The image field is base64-encoded JPEG bytes, not a path. Decode in-process."""
+    print(f"[scp/embspatial] hf_hub_download metadata from {EMBSPATIAL_REPO}", flush=True)
+    try:
+        from huggingface_hub import hf_hub_download
+        meta_path = hf_hub_download(
+            repo_id=EMBSPATIAL_REPO,
+            filename="embspatial_bench.json",
+            repo_type="dataset",
+        )
+    except Exception as e:
+        print(f"[scp/embspatial] hf_hub_download failed: {e}", flush=True)
+        return start_offset, False
+    with open(meta_path) as f:
+        items = json.load(f)
+    print(f"[scp/embspatial] {len(items)} items, start_offset={start_offset}", flush=True)
+    last_idx = start_offset
+    for idx, item in enumerate(items):
+        if idx < start_offset:
+            continue
+        last_idx = idx
+        image_b64 = item.get("image")
+        if not image_b64 or not isinstance(image_b64, str):
+            continue
+        try:
+            img_bytes = base64.b64decode(image_b64)
+            image = Image.open(io.BytesIO(img_bytes))
+        except Exception:
+            continue
+        question = item.get("question") or ""
+        options = item.get("answer_options") or []
+        answer = item.get("answer")
+        if isinstance(answer, int) and 0 <= answer < len(options):
+            answer_text = str(options[answer])
+        else:
+            answer_text = str(answer) if answer is not None else ""
+        if not answer_text:
+            continue
+        option_text = "\n".join(f"{chr(65+i)}. {o}" for i, o in enumerate(options))
+        full_q = f"{question}\nOptions:\n{option_text}" if option_text else question
+        conversations = [
+            {"from": "human", "value": f"<image>\n{full_q}"},
+            {"from": "gpt", "value": answer_text},
+        ]
+        local_rel = f"{SOURCE_NAME}/embspatial/embspatial_{idx:06d}.jpg"
+        local_full = images_dir / local_rel
+        if local_full.exists() and local_full.stat().st_size >= MIN_IMAGE_BYTES:
+            size = local_full.stat().st_size
+        else:
+            try:
+                size = _save_pil(image, local_full)
+            except Exception:
+                size = None
+            if size is None:
+                continue
+        meta = {"source": SOURCE_NAME, "repo": EMBSPATIAL_REPO, "subset": "embspatial", "row": idx}
+        if not on_record(local_rel, conversations, size, meta, idx):
+            return last_idx, False
+    return last_idx + 1, True
+
+
+def _collect_synthdog(images_dir, on_record, start_offset=0, max_items=200000):
+    print(f"[scp/synthdog] streaming {SYNTHDOG_REPO} from idx={start_offset}", flush=True)
+    try:
+        ds = load_dataset(SYNTHDOG_REPO, split="train", streaming=True)
+    except Exception as e:
+        print(f"[scp/synthdog] load_dataset failed: {e}", flush=True)
+        return start_offset, False
+    last_idx = start_offset
+    for idx, item in enumerate(ds):
+        if idx < start_offset:
+            continue
+        if idx >= max_items:
+            return last_idx, True
+        last_idx = idx
+        image = item.get("image")
+        gt = item.get("ground_truth") or item.get("text") or ""
+        if image is None:
+            continue
+        if isinstance(gt, str) and gt.startswith("{"):
+            try:
+                gt_obj = json.loads(gt)
+                gt_text = gt_obj.get("gt_parse", {}).get("text_sequence") or json.dumps(gt_obj, ensure_ascii=False)[:2000]
+            except Exception:
+                gt_text = gt[:2000]
+        else:
+            gt_text = str(gt)[:2000]
+        if not gt_text:
+            continue
+        local_rel = f"{SOURCE_NAME}/synthdog/{idx:08d}.jpg"
+        local_full = images_dir / local_rel
+        if local_full.exists() and local_full.stat().st_size >= MIN_IMAGE_BYTES:
+            size = local_full.stat().st_size
+        else:
+            try:
+                size = _save_pil(image, local_full)
+            except Exception:
+                size = None
+            if size is None:
+                continue
+        conversations = [
+            {"from": "human", "value": "<image>\nRead all visible text in the image."},
+            {"from": "gpt", "value": gt_text},
+        ]
+        meta = {"source": SOURCE_NAME, "repo": SYNTHDOG_REPO, "subset": "synthdog_en", "row": idx}
+        if not on_record(local_rel, conversations, size, meta, idx):
+            return last_idx, False
+    return last_idx + 1, True
+
+
+def _collect_cord(images_dir, on_record, start_offset=0):
+    print(f"[scp/cord] streaming {CORD_REPO} from idx={start_offset}", flush=True)
+    try:
+        ds = load_dataset(CORD_REPO, split="train", streaming=True)
+    except Exception as e:
+        print(f"[scp/cord] load_dataset failed: {e}", flush=True)
+        return start_offset, False
+    last_idx = start_offset
+    for idx, item in enumerate(ds):
+        if idx < start_offset:
+            continue
+        last_idx = idx
+        image = item.get("image")
+        gt = item.get("ground_truth") or ""
+        if image is None or not gt:
+            continue
+        try:
+            gt_obj = json.loads(gt) if isinstance(gt, str) else gt
+            valid_lines = gt_obj.get("valid_line", [])
+            text_parts = []
+            for line in valid_lines:
+                for w in line.get("words", []):
+                    text_parts.append(w.get("text", ""))
+            text = " ".join(text_parts)[:1500]
+        except Exception:
+            text = ""
+        if not text:
+            continue
+        local_rel = f"{SOURCE_NAME}/cord/{idx:08d}.jpg"
+        local_full = images_dir / local_rel
+        if local_full.exists() and local_full.stat().st_size >= MIN_IMAGE_BYTES:
+            size = local_full.stat().st_size
+        else:
+            try:
+                size = _save_pil(image, local_full)
+            except Exception:
+                size = None
+            if size is None:
+                continue
+        conversations = [
+            {"from": "human", "value": "<image>\nExtract all text from this receipt."},
+            {"from": "gpt", "value": text},
+        ]
+        meta = {"source": SOURCE_NAME, "repo": CORD_REPO, "subset": "cord_v2", "row": idx}
+        if not on_record(local_rel, conversations, size, meta, idx):
+            return last_idx, False
+    return last_idx + 1, True
+
+
+PIPELINE = [
+    ("uground", _collect_uground),
+    ("embspatial", _collect_embspatial),
+    ("synthdog_en", _collect_synthdog),
+    ("cord_v2", _collect_cord),
+]
+
+
+def collect_at_scale(
+    target_image_bytes,
+    annotations_dir,
+    images_dir,
+    raw_dir,
+    progress_path,
+    episode_batch_size=10000,
+    disk_check_every=200,
+    disk_floor_gb=100,
+    seen_image_keys=None,
+):
+    annotations_dir = Path(annotations_dir)
+    images_dir = Path(images_dir)
+    progress_path = Path(progress_path)
+    (images_dir / SOURCE_NAME).mkdir(parents=True, exist_ok=True)
+
+    fuse = DiskFuse(annotations_dir, disk_floor_gb)
+    writer = DurableEpisodeWriter(annotations_dir, progress_path, SOURCE_NAME, episode_batch_size)
+    print(f"[scp] resume rows={writer.flushed_rows} bytes={writer.flushed_bytes/1024**3:.2f}GB", flush=True)
+
+    completed_subsets = set(writer.get_extra("completed_subsets", []))
+    subset_offsets = dict(writer.get_extra("subset_offsets", {}))
+    subset_bytes_record = dict(writer.get_extra("subset_bytes_record", {}))
+
+    report = CollectorReport(source=SOURCE_NAME)
+    report.skipped["ok"] = 0
+    report.skipped["subset_failed"] = 0
+
+    images_since_check = [0]
+    current_subset_name = [None]
+
+    def coverage_done():
+        cfg = _COVERAGE_MIN.get(SOURCE_NAME, {})
+        for k, min_b in cfg.items():
+            if k.startswith("_"):
+                continue
+            if subset_bytes_record.get(k, 0) < min_b:
+                return False
+        return True
+
+    def on_record(local_rel, conversations, size, meta, idx):
+        # coverage-aware: keep collecting even past target_bytes if a required subset is missing
+        if writer.total_bytes >= target_image_bytes and coverage_done():
+            return False
+        row = {
+            "images_1": {"type": "image", "url": local_rel},
+            "conversations": normalize_conversations(conversations),
+            "is_robot": False,
+        }
+        writer.add(row, size, meta, None)
+        if current_subset_name[0]:
+            subset_bytes_record[current_subset_name[0]] = subset_bytes_record.get(current_subset_name[0], 0) + size
+        report.skipped["ok"] += 1
+        images_since_check[0] += 1
+        if images_since_check[0] >= disk_check_every:
+            fuse.check()
+            images_since_check[0] = 0
+        if writer.should_flush():
+            if current_subset_name[0] is not None:
+                subset_offsets[current_subset_name[0]] = idx + 1
+                writer.update_extra(
+                    completed_subsets=list(completed_subsets),
+                    subset_offsets=subset_offsets,
+                    subset_bytes_record=subset_bytes_record,
+                )
+            out = writer.flush()
+            if out:
+                print(f"[scp] flushed {out.name} rows={writer.flushed_rows} bytes={writer.flushed_bytes/1024**3:.2f}GB", flush=True)
+        return True
+
+    for name, fn in PIPELINE:
+        if writer.total_bytes >= target_image_bytes and coverage_done():
+            print(f"[scp] target reached and coverage satisfied, stop", flush=True)
+            break
+        cfg = _COVERAGE_MIN.get(SOURCE_NAME, {})
+        min_b = cfg.get(name, 0)
+        actual = subset_bytes_record.get(name, 0)
+        progress_v = int(writer.get_extra("progress_version", 0))
+        if actual >= min_b and (
+            name in completed_subsets
+            or progress_v >= 2
+            or writer.total_bytes >= target_image_bytes
+        ):
+            print(f"[scp] skip {name} (bytes={actual/1024**2:.1f}MB >= {min_b/1024**2:.1f}MB)", flush=True)
+            completed_subsets.add(name)
+            writer.update_extra(
+                completed_subsets=list(completed_subsets),
+                subset_offsets=subset_offsets,
+                subset_bytes_record=subset_bytes_record,
+            )
+            continue
+        if name in completed_subsets and actual < min_b:
+            print(f"[scp] FORCE re-collect {name}: bytes={actual/1024**2:.1f}MB < min={min_b/1024**2:.1f}MB", flush=True)
+            completed_subsets.discard(name)
+
+        print(f"[scp] === subset {name} === current={writer.total_bytes/1024**3:.2f}GB", flush=True)
+        rows_before = writer.total_rows
+        bytes_before = writer.total_bytes
+        current_subset_name[0] = name
+        try:
+            last_idx, exhausted = fn(images_dir, on_record, start_offset=int(subset_offsets.get(name, 0)))
+        except Exception as e:
+            print(f"[scp] subset {name} crashed: {e}", flush=True)
+            report.skipped["subset_failed"] += 1
+            continue
+
+        subset_collected = writer.total_bytes - bytes_before
+        subset_offsets[name] = last_idx
+        if subset_collected > 0 and exhausted:
+            completed_subsets.add(name)
+        elif exhausted and writer.total_rows == rows_before:
+            completed_subsets.add(name)
+        writer.update_extra(
+            completed_subsets=list(completed_subsets),
+            subset_offsets=subset_offsets,
+            subset_bytes_record=subset_bytes_record,
+        )
+
+    if writer._pending_rows:
+        out = writer.flush()
+        if out:
+            print(f"[scp] final flush {out.name} rows={writer.flushed_rows} bytes={writer.flushed_bytes/1024**3:.2f}GB", flush=True)
+    writer.final_save(
+        completed_subsets=list(completed_subsets),
+        subset_offsets=subset_offsets,
+        subset_bytes_record=subset_bytes_record,
+    )
+
+    report.rows = writer.flushed_rows
+    report.image_bytes = writer.flushed_bytes
+    report.jsonl_files = writer.jsonl_files
+    report.items_meta = writer._pending_meta_history
+    print(f"[scp] DONE rows={writer.flushed_rows} bytes={writer.flushed_bytes/1024**3:.2f}GB "
+          f"completed={len(completed_subsets)}/{len(PIPELINE)} skipped={dict(report.skipped)}", flush=True)
+    return report

--- a/midtrain_vl_50gb/tools/disk_guard.py
+++ b/midtrain_vl_50gb/tools/disk_guard.py
@@ -1,0 +1,31 @@
+# Pre-flight and runtime disk-space checks for long-running collectors.
+import shutil
+from pathlib import Path
+
+
+def free_bytes(path):
+    return shutil.disk_usage(path).free
+
+
+def precheck(target_path, min_free_gb):
+    free = free_bytes(target_path)
+    if free < min_free_gb * 1024**3:
+        raise RuntimeError(
+            f"Disk too small at {target_path}: need {min_free_gb}GB, have {free/1024**3:.2f}GB"
+        )
+    return free
+
+
+class DiskFuse:
+    def __init__(self, target_path, floor_gb):
+        self.target_path = Path(target_path)
+        self.floor = floor_gb * 1024**3
+
+    def check(self):
+        f = free_bytes(self.target_path)
+        if f < self.floor:
+            raise RuntimeError(
+                f"Disk fuse triggered at {self.target_path}: "
+                f"{f/1024**3:.2f}GB free < {self.floor/1024**3:.2f}GB floor"
+            )
+        return f

--- a/midtrain_vl_50gb/tools/precompute_index_cache.py
+++ b/midtrain_vl_50gb/tools/precompute_index_cache.py
@@ -1,0 +1,54 @@
+# Pre-compute dexbotic DexDataset index_cache.json so the first-time DexDataset
+# constructor doesn't have to scan all jsonl files (saves 30-60s on cold start).
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from recipe import ANNOTATIONS_DIR, COLLECTOR_ORDER
+
+
+def precompute_one(annotation_dir):
+    annotation_dir = Path(annotation_dir)
+    files = sorted(annotation_dir.glob("episode_*.jsonl"))
+    cache = {
+        "meta_data": {"total_samples": 0, "total_jsonl_files": len(files)},
+        "data": {},
+    }
+    for f in files:
+        with f.open() as fh:
+            n = sum(1 for _ in fh)
+        cache["data"][str(f.absolute())] = n
+        cache["meta_data"]["total_samples"] += n
+    out = annotation_dir / "index_cache.json"
+    out.write_text(json.dumps(cache, indent=2, ensure_ascii=False))
+    return cache["meta_data"]["total_samples"]
+
+
+def precompute_all():
+    total = 0
+    for src in COLLECTOR_ORDER:
+        d = ANNOTATIONS_DIR / src
+        if not d.exists():
+            continue
+        n = precompute_one(d)
+        print(f"{src}: {n} samples")
+        total += n
+    print(f"total: {total} samples")
+    return total
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--source", default=None)
+    args = p.parse_args()
+    if args.source:
+        n = precompute_one(ANNOTATIONS_DIR / args.source)
+        print(f"{args.source}: {n} samples")
+    else:
+        precompute_all()
+
+
+if __name__ == "__main__":
+    main()

--- a/midtrain_vl_50gb/tools/prepare.py
+++ b/midtrain_vl_50gb/tools/prepare.py
@@ -1,0 +1,185 @@
+# Entrypoint for the 50GB VL collection. Auto-discovers collectors from
+# tools/collectors/ via tools/recipe.COLLECTOR_ORDER. Resumes automatically.
+import argparse
+import importlib
+import json
+import shutil
+import sys
+import time
+from pathlib import Path
+
+THIS_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(THIS_DIR))
+
+import disk_guard
+import precompute_index_cache
+from recipe import (
+    ANNOTATIONS_DIR,
+    COLLECTOR_ORDER,
+    DATA_SOURCE_DIR,
+    DISK_CHECK_EVERY,
+    DISK_FLOOR_GB,
+    EPISODE_BATCH_SIZE,
+    IMAGES_DIR,
+    PROGRESS_DIR,
+    RAW_DIR,
+    RECIPE,
+    REGISTER_PREFIX,
+    ROOT_DIR,
+)
+
+
+def parse_size(text):
+    text = text.strip().upper()
+    if text.endswith("G"):
+        return int(float(text[:-1]) * 1024**3)
+    if text.endswith("M"):
+        return int(float(text[:-1]) * 1024**2)
+    if text.endswith("K"):
+        return int(float(text[:-1]) * 1024)
+    return int(text)
+
+
+def ensure_dirs():
+    for p in (ANNOTATIONS_DIR, IMAGES_DIR, RAW_DIR, PROGRESS_DIR, DATA_SOURCE_DIR, ROOT_DIR / "docs"):
+        p.mkdir(parents=True, exist_ok=True)
+    for src in COLLECTOR_ORDER:
+        (ANNOTATIONS_DIR / src).mkdir(parents=True, exist_ok=True)
+        (IMAGES_DIR / src).mkdir(parents=True, exist_ok=True)
+
+
+def write_data_source_register():
+    """Generate a local data_source register file. The official one in
+    `dexbotic/data/data_source/dm0vl_midtrain_official.py` is preferred for PRs;
+    this file is a local fallback when DM0_VL_ROOT differs from upstream layout."""
+    out = DATA_SOURCE_DIR / "dm0_vl_midtrain_50gb.py"
+    images_root = str(IMAGES_DIR.resolve())
+    annotations_root = str(ANNOTATIONS_DIR.resolve())
+    lines = [
+        "# Auto-generated. Do not edit by hand.",
+        "from dexbotic.data.data_source.register import register_dataset",
+        "",
+        "",
+        "DM0_VL_MIDTRAIN_50GB = {",
+    ]
+    for src in COLLECTOR_ORDER:
+        annot_dir = ANNOTATIONS_DIR / src
+        if not list(annot_dir.glob("episode_*.jsonl")):
+            print(f"[register] skip {src} (no jsonl)")
+            continue
+        lines.append(
+            f'    "{src}": {{"data_path_prefix": r"{images_root}", '
+            f'"annotations": r"{annotations_root}/{src}", "frequency": 1}},'
+        )
+    lines += [
+        "}",
+        "",
+        f'register_dataset(DM0_VL_MIDTRAIN_50GB, meta_data={{}}, prefix="{REGISTER_PREFIX}")',
+        "",
+    ]
+    out.write_text("\n".join(lines), encoding="utf-8")
+    return out
+
+
+def cleanup_raw(source):
+    target = RAW_DIR / source
+    if target.exists():
+        size_before = sum(f.stat().st_size for f in target.rglob("*") if f.is_file())
+        shutil.rmtree(target)
+        return size_before
+    return 0
+
+
+def run_one(source, target_bytes):
+    if source not in RECIPE:
+        raise KeyError(f"unknown source: {source}")
+    cfg = RECIPE[source]
+    if target_bytes is None:
+        target_bytes = cfg["target_image_bytes"]
+    print(f"[main] source={source} target={target_bytes/1024**3:.2f}GB", flush=True)
+    disk_guard.precheck(ROOT_DIR, max(80, int(target_bytes / 1024**3) + 20))
+
+    module = importlib.import_module(f"collectors.{source}")
+    progress_path = PROGRESS_DIR / f"{source}.json"
+    t0 = time.time()
+    report = module.collect_at_scale(
+        target_image_bytes=target_bytes,
+        annotations_dir=ANNOTATIONS_DIR / source,
+        images_dir=IMAGES_DIR,
+        raw_dir=RAW_DIR,
+        progress_path=progress_path,
+        episode_batch_size=EPISODE_BATCH_SIZE,
+        disk_check_every=DISK_CHECK_EVERY,
+        disk_floor_gb=DISK_FLOOR_GB,
+    )
+    elapsed = time.time() - t0
+    raw_freed = cleanup_raw(source)
+    precompute_index_cache.precompute_one(ANNOTATIONS_DIR / source)
+
+    summary = {
+        "source": source,
+        "rows": report.rows,
+        "image_bytes": report.image_bytes,
+        "image_gb": report.image_bytes / 1024**3,
+        "elapsed_sec": elapsed,
+        "skipped": dict(report.skipped),
+        "jsonl_files": report.jsonl_files,
+        "raw_bytes_freed": raw_freed,
+    }
+    out = PROGRESS_DIR / f"manifest_{source}.json"
+    out.write_text(json.dumps(
+        {"summary": summary, "items_count": len(report.items_meta), "items_head": report.items_meta[:50]},
+        ensure_ascii=False, indent=2,
+    ))
+    print(f"[main] {source} done rows={report.rows} bytes={report.image_bytes/1024**3:.2f}GB elapsed={elapsed:.1f}s", flush=True)
+    return summary
+
+
+def write_global_manifest(per_source_summaries):
+    total_rows = sum(s["rows"] for s in per_source_summaries)
+    total_bytes = sum(s["image_bytes"] for s in per_source_summaries)
+    payload = {
+        "version": "1",
+        "total_rows": total_rows,
+        "total_image_bytes": total_bytes,
+        "total_image_gb": total_bytes / 1024**3,
+        "sources": {s["source"]: {k: v for k, v in s.items() if k != "jsonl_files"} for s in per_source_summaries},
+        "register_prefix": REGISTER_PREFIX,
+    }
+    out = ROOT_DIR / "manifest.json"
+    out.write_text(json.dumps(payload, ensure_ascii=False, indent=2))
+    return out
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--source", default=None, help="single source name; default=all")
+    p.add_argument("--target-bytes", default=None, help="override target (e.g. 5G)")
+    p.add_argument("--dry-run", action="store_true")
+    args = p.parse_args()
+
+    ensure_dirs()
+    if args.dry_run:
+        print(f"[dry-run] root={ROOT_DIR}")
+        for src in COLLECTOR_ORDER:
+            cfg = RECIPE[src]
+            print(f"  {src}: target={cfg['target_image_bytes']/1024**3:.1f}GB")
+        return 0
+
+    target_bytes = parse_size(args.target_bytes) if args.target_bytes else None
+    sources = [args.source] if args.source else COLLECTOR_ORDER
+
+    summaries = []
+    for src in sources:
+        summaries.append(run_one(src, target_bytes))
+
+    write_data_source_register()
+    if args.source is None:
+        precompute_index_cache.precompute_all()
+        m = write_global_manifest(summaries)
+        print(f"[main] manifest -> {m}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/midtrain_vl_50gb/tools/recipe.py
+++ b/midtrain_vl_50gb/tools/recipe.py
@@ -1,0 +1,79 @@
+# Single source of truth for collection targets and subset lists.
+# Layout is rooted at ${DM0_VL_ROOT}; export it before running any tool.
+import os
+from pathlib import Path
+
+ROOT_DIR = Path(os.environ.get("DM0_VL_ROOT", "data/dm0_vl_midtrain_50gb"))
+ANNOTATIONS_DIR = ROOT_DIR / "annotations"
+IMAGES_DIR = ROOT_DIR / "images"
+RAW_DIR = ROOT_DIR / "raw"
+PROGRESS_DIR = ROOT_DIR / ".progress"
+DATA_SOURCE_DIR = ROOT_DIR / "data_source"
+
+REGISTER_PREFIX = "dm0vlmid"
+
+# Paper §3.2 VL split. cambrian10m is source-limited by COCO pool dedup;
+# llava_onevision absorbs the deficit through a wider subset list.
+RECIPE = {
+    "cambrian10m_filtered": {
+        "target_image_bytes": 20 * 1024**3,
+        "estimated_avg_kb": 80,
+    },
+    "cambrian737k": {
+        "target_image_bytes": 12 * 1024**3,
+        "estimated_avg_kb": 80,
+    },
+    "llava_onevision": {
+        "target_image_bytes": 22 * 1024**3,
+        "estimated_avg_kb": 100,
+        "subsets": [
+            "chartqa(cauldron,llava_format)",
+            "ai2d(cauldron,llava_format)",
+            "sharegpt4v(coco)",
+            "scienceqa(cauldron,llava_format)",
+            "dvqa(cauldron,llava_format)",
+            "sharegpt4v(llava)",
+            "sharegpt4v(sam)",
+            "aokvqa(cauldron,llava_format)",
+            "vsr(cauldron,llava_format)",
+            "tallyqa(cauldron,llava_format)",
+            "iconqa(cauldron,llava_format)",
+            "chart2text(cauldron)",
+            "llavar_gpt4_20k",
+            "rendered_text(cauldron)",
+            "infographic_vqa_llava_format",
+            "image_textualization(filtered)",
+            "sharegpt4v(knowledge)",
+            "visualmrc(cauldron)",
+            "hateful_memes(cauldron,llava_format)",
+            "intergps(cauldron,llava_format)",
+            "robut_wtq(cauldron,llava_format)",
+            "vistext(cauldron)",
+            "visual7w(cauldron,llava_format)",
+            "tqa(cauldron,llava_format)",
+            "allava_instruct_vflan4v",
+            "robut_wikisql(cauldron)",
+            "mapqa(cauldron,llava_format)",
+            "textcaps",
+            "ureader_cap",
+            "vision_flan(filtered)",
+        ],
+    },
+    "self_collected_proxy": {
+        "target_image_bytes": 8 * 1024**3,
+        "estimated_avg_kb": 100,
+        "subsets": ["uground", "embspatial", "synthdog_en", "cord_v2"],
+    },
+}
+
+TOTAL_TARGET_BYTES = 50 * 1024**3
+DISK_FLOOR_GB = 100
+EPISODE_BATCH_SIZE = 10000
+DISK_CHECK_EVERY = 200
+
+COLLECTOR_ORDER = [
+    "cambrian737k",
+    "cambrian10m_filtered",
+    "llava_onevision",
+    "self_collected_proxy",
+]

--- a/midtrain_vl_50gb/tools/reconcile_progress.py
+++ b/midtrain_vl_50gb/tools/reconcile_progress.py
@@ -1,0 +1,141 @@
+# Rebuild progress.json from on-disk jsonl + image stats.
+# Run before resuming a partial collection with newer code; lets the
+# DurableEpisodeWriter pick up where the disk actually left off.
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from recipe import ANNOTATIONS_DIR, COLLECTOR_ORDER, IMAGES_DIR, PROGRESS_DIR
+
+# Sources whose `subset_bytes_record` should be rebuilt from disk. Their jsonl
+# image URLs use a 3-segment path (source/subset/file), so we can recover
+# subset-level counts from disk facts alone.
+RESET_EXTRA_SOURCES = {"llava_onevision", "self_collected_proxy"}
+RESET_EXTRA_KEYS = {"completed_subsets", "subset_offsets", "subset_bytes_record"}
+
+# self_collected_proxy v3 wrote images under "synthdog/" and "cord/" but the
+# canonical subset names (matching coverage gate + collector PIPELINE) are
+# "synthdog_en" and "cord_v2". Apply the alias on rebuild.
+SCP_SUBSET_ALIAS = {"synthdog": "synthdog_en", "cord": "cord_v2"}
+
+
+def _parse_subset_key(url, source):
+    parts = url.split("/", 2)
+    if len(parts) < 3:
+        return None
+    key = parts[1]
+    if source == "self_collected_proxy":
+        return SCP_SUBSET_ALIAS.get(key, key)
+    return key
+
+
+def reconcile_one(source, dry_run=False, reset_extra=False):
+    annotation_dir = Path(ANNOTATIONS_DIR) / source
+    progress_path = Path(PROGRESS_DIR) / f"{source}.json"
+    if not annotation_dir.exists():
+        print(f"[reconcile] {source}: annotation dir missing, skip")
+        return None
+    files = sorted(annotation_dir.glob("episode_*.jsonl"))
+    real_rows = 0
+    real_bytes = 0
+    seen_keys = set()
+    rebuilt_subset_bytes = {}
+    bad_lines = 0
+    missing_images = 0
+    for f in files:
+        with f.open() as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                except Exception:
+                    bad_lines += 1
+                    continue
+                real_rows += 1
+                images_1 = rec.get("images_1") or {}
+                url = images_1.get("url")
+                if not url:
+                    continue
+                p = Path(IMAGES_DIR) / url
+                if not p.exists():
+                    missing_images += 1
+                    continue
+                try:
+                    sz = p.stat().st_size
+                except Exception:
+                    missing_images += 1
+                    continue
+                real_bytes += sz
+                seen_keys.add(p.name)
+                sub = _parse_subset_key(url, source)
+                if sub:
+                    rebuilt_subset_bytes[sub] = rebuilt_subset_bytes.get(sub, 0) + sz
+    next_episode = max(
+        len(files),
+        (int(files[-1].stem.rsplit("_", 1)[-1]) + 1) if files else 0,
+    )
+
+    old_progress = {}
+    if progress_path.exists():
+        try:
+            old_progress = json.loads(progress_path.read_text())
+        except Exception:
+            old_progress = {}
+    new_progress = {
+        "rows": real_rows,
+        "image_bytes": real_bytes,
+        "next_episode": next_episode,
+        "seen_image_keys": list(seen_keys),
+        "progress_version": 2,
+    }
+    if source in RESET_EXTRA_SOURCES and rebuilt_subset_bytes:
+        new_progress["subset_bytes_record"] = rebuilt_subset_bytes
+        print(f"[reconcile] {source}: rebuilt subset_bytes_record="
+              f"{ {k: round(v/1024**2, 1) for k, v in rebuilt_subset_bytes.items()} }MB")
+    base_keys = set(new_progress.keys()) | {"subset_bytes_record"}
+    auto_reset = reset_extra or (source in RESET_EXTRA_SOURCES)
+    skipped = []
+    for k, v in old_progress.items():
+        if k in base_keys:
+            continue
+        if auto_reset and k in RESET_EXTRA_KEYS:
+            skipped.append(k)
+            continue
+        new_progress[k] = v
+    if skipped:
+        print(f"[reconcile] {source}: dropped legacy extra {skipped}")
+
+    print(f"[reconcile] {source}: rows={real_rows} bytes={real_bytes/1024**3:.2f}GB "
+          f"jsonl_files={len(files)} next_episode={next_episode} "
+          f"bad_lines={bad_lines} missing_images={missing_images}")
+
+    if dry_run:
+        print(f"[reconcile] {source}: DRY RUN, not writing")
+        return new_progress
+
+    if progress_path.exists():
+        progress_path.with_suffix(".json.before_reconcile").write_text(progress_path.read_text())
+    tmp = progress_path.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(new_progress, ensure_ascii=False, indent=2))
+    tmp.replace(progress_path)
+    return new_progress
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--source", default=None)
+    p.add_argument("--dry-run", action="store_true")
+    p.add_argument("--reset-extra", action="store_true",
+                   help="force-reset completed_subsets/subset_offsets/subset_bytes_record for all sources")
+    args = p.parse_args()
+    sources = [args.source] if args.source else COLLECTOR_ORDER
+    for src in sources:
+        reconcile_one(src, dry_run=args.dry_run, reset_extra=args.reset_extra)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/midtrain_vl_50gb/tools/subset_coverage_check.py
+++ b/midtrain_vl_50gb/tools/subset_coverage_check.py
@@ -1,0 +1,80 @@
+# Subset-coverage gate. Catches the failure mode where source bytes hit target
+# but a critical subset (e.g. embspatial) is empty.
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from recipe import COLLECTOR_ORDER, PROGRESS_DIR
+
+# Per-source minimum bytes thresholds. Aligned with paper §3.2 intent for
+# subset diversity; tune via PR if downstream tasks need stronger guarantees.
+MIN_SUBSET_BYTES = {
+    "self_collected_proxy": {
+        "uground": 500 * 1024 * 1024,
+        "embspatial": 50 * 1024 * 1024,
+        "synthdog_en": 100 * 1024 * 1024,
+        "cord_v2": 10 * 1024 * 1024,
+    },
+    "llava_onevision": {
+        "_min_subset_count": 5,
+        "_min_per_subset_bytes": 100 * 1024 * 1024,
+    },
+}
+
+
+def check_source_coverage(source):
+    progress_path = Path(PROGRESS_DIR) / f"{source}.json"
+    if not progress_path.exists():
+        return False, [f"{source}: progress.json missing"]
+    try:
+        progress = json.loads(progress_path.read_text())
+    except Exception as e:
+        return False, [f"{source}: progress.json parse error: {e}"]
+    failures = []
+    cfg = MIN_SUBSET_BYTES.get(source, {})
+    record = progress.get("subset_bytes_record", {})
+    for subset, min_bytes in cfg.items():
+        if subset.startswith("_"):
+            continue
+        actual = record.get(subset, 0)
+        if actual < min_bytes:
+            failures.append(f"{source}.{subset}: only {actual/1024**2:.1f}MB < {min_bytes/1024**2:.1f}MB")
+    min_count = cfg.get("_min_subset_count")
+    min_per = cfg.get("_min_per_subset_bytes")
+    if min_count and min_per:
+        valid = [s for s, b in record.items() if not s.startswith("_") and b >= min_per]
+        if len(valid) < min_count:
+            failures.append(
+                f"{source}: only {len(valid)} subsets >= {min_per/1024**2:.0f}MB, need {min_count}"
+            )
+    return len(failures) == 0, failures
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--source", default=None)
+    p.add_argument("--strict", action="store_true",
+                   help="exit 1 if any source falls below subset coverage thresholds")
+    args = p.parse_args()
+    sources = [args.source] if args.source else COLLECTOR_ORDER
+    all_failures = []
+    for src in sources:
+        ok, fails = check_source_coverage(src)
+        if ok:
+            print(f"[coverage] {src}: OK")
+        else:
+            for f in fails:
+                print(f"[coverage] FAIL: {f}")
+                all_failures.append(f)
+    if all_failures:
+        if args.strict:
+            print(f"[coverage] STRICT FAIL: {len(all_failures)} subset coverage failures")
+            return 1
+        print(f"[coverage] WARN: {len(all_failures)} subset coverage failures (use --strict to fail)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/midtrain_vl_50gb/tools/test_dataloader.py
+++ b/midtrain_vl_50gb/tools/test_dataloader.py
@@ -1,0 +1,111 @@
+# End-to-end DexDataset + DataCollator smoke test. Fail-closed: exits non-zero
+# if any registered source is missing or any sample fails to load.
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+import torch
+from easydict import EasyDict
+from torch.utils.data import DataLoader
+
+THIS_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(THIS_DIR))
+from recipe import COLLECTOR_ORDER, REGISTER_PREFIX, ROOT_DIR  # noqa: E402
+
+
+class TinyTokenizer:
+    pad_token_id = 0
+    eos_token_id = 1
+    model_max_length = 32
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--dataset-name", default=None)
+    p.add_argument("--batch-size", type=int, default=4)
+    p.add_argument("--allow-missing", action="store_true",
+                   help="skip unregistered sources instead of failing")
+    args = p.parse_args()
+
+    os.environ.setdefault("DEXBOTIC_DATA_PATH", str(ROOT_DIR / "data_source"))
+
+    import dexbotic.data.data_source  # noqa: F401
+    from dexbotic.data.collator import DataCollatorForSupervisedDataset
+    from dexbotic.data.data_source.register import CONVERSATION_DATA
+    from dexbotic.data.dataset.dex_dataset import DexDataset
+    from dexbotic.data.dataset.rgb_preprocess import DummyRGBProcessor
+    from dexbotic.data.dataset.tokenization import DummyTokenization
+    from dexbotic.data.dataset.transform.common import Pipeline, ToDict, ToList, ToNumpy
+    from dexbotic.data.dataset.transform.multimodal import LoadMultiModal
+
+    if args.dataset_name is None:
+        ds_name = "+".join(f"{REGISTER_PREFIX}_{s}" for s in COLLECTOR_ORDER)
+    else:
+        ds_name = args.dataset_name
+
+    missing = [n for n in ds_name.split("+") if n not in CONVERSATION_DATA]
+    present = [n for n in ds_name.split("+") if n in CONVERSATION_DATA]
+    if missing and not args.allow_missing:
+        raise AssertionError(f"missing registered datasets: {missing} (use --allow-missing to skip)")
+    if missing:
+        print(f"[test] WARN: skipping missing: {missing}")
+    if not present:
+        raise AssertionError("no registered dataset to test")
+    ds_name = "+".join(present)
+
+    action_process_func = Pipeline([ToDict(), ToNumpy(), LoadMultiModal(), ToList()])
+    data_args = EasyDict(
+        dataset_name=ds_name,
+        num_images=1,
+        data_keys=["input_ids", "labels", "image"],
+        images_keys=None,
+        depths_keys=None,
+        load_depth=False,
+        discrete_state_input=False,
+        aug_policy=None,
+        image_aspect_ratio=None,
+    )
+    dataset = DexDataset(
+        data_args=data_args,
+        tokenization_func=DummyTokenization(),
+        action_process_func=action_process_func,
+        image_process_func=DummyRGBProcessor(),
+        depth_process_func=lambda _: torch.zeros(1),
+    )
+
+    n = len(dataset)
+    print(f"[test] dataset_name={ds_name} dataset_len={n}")
+    if n == 0:
+        raise AssertionError("empty dataset")
+
+    for idx in [0, n // 8, n // 4, n // 2, n - 1]:
+        item = dataset[idx]
+        for k in ("input_ids", "labels", "image"):
+            if k not in item:
+                raise AssertionError(f"sample {idx} missing {k}")
+
+    loader = DataLoader(
+        dataset,
+        batch_size=args.batch_size,
+        shuffle=False,
+        collate_fn=DataCollatorForSupervisedDataset(TinyTokenizer()),
+    )
+    batch = next(iter(loader))
+    required = {"input_ids", "labels", "attention_mask", "images"}
+    if not required.issubset(batch):
+        raise AssertionError(f"batch missing keys: {required - set(batch)}")
+
+    summary = {
+        "dataset_name": ds_name,
+        "dataset_len": n,
+        "batch_keys": sorted(batch.keys()),
+        "batch_shapes": {k: list(v.shape) for k, v in batch.items() if hasattr(v, "shape")},
+    }
+    print(json.dumps(summary, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/midtrain_vl_50gb/tools/verify_dataset.py
+++ b/midtrain_vl_50gb/tools/verify_dataset.py
@@ -1,0 +1,97 @@
+# Random-sample validation of collected jsonl. Verifies image files load with
+# PIL and conversations contain `<image>` tokens. Fail-closed by default.
+import argparse
+import json
+import random
+import sys
+from pathlib import Path
+
+from PIL import Image
+
+THIS_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(THIS_DIR))
+from recipe import ANNOTATIONS_DIR, COLLECTOR_ORDER, IMAGES_DIR  # noqa: E402
+
+
+def collect_samples(source, num_samples, rng):
+    files = sorted((ANNOTATIONS_DIR / source).glob("episode_*.jsonl"))
+    if not files:
+        return []
+    samples = []
+    chosen = rng.sample(files, min(len(files), max(1, num_samples // 100)))
+    for f in chosen:
+        with f.open() as fh:
+            lines = fh.readlines()
+        rng.shuffle(lines)
+        for line in lines[:num_samples]:
+            try:
+                rec = json.loads(line)
+            except Exception:
+                continue
+            samples.append((source, rec))
+            if len(samples) >= num_samples:
+                return samples
+    return samples
+
+
+def verify_one(source, rec):
+    images_1 = rec.get("images_1") or {}
+    url = images_1.get("url")
+    if not url:
+        return False, "missing_url"
+    p = IMAGES_DIR / url
+    if not p.exists():
+        return False, f"image_not_found:{p}"
+    try:
+        Image.open(p).verify()
+    except Exception as e:
+        return False, f"pil_error:{e}"
+    convs = rec.get("conversations") or []
+    if not convs:
+        return False, "no_conversations"
+    if not any("<image>" in (t.get("value") or "") for t in convs if isinstance(t, dict)):
+        return False, "no_image_token"
+    return True, "ok"
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--source", default=None)
+    p.add_argument("--num-samples", type=int, default=256)
+    p.add_argument("--allow-empty", action="store_true",
+                   help="don't fail on empty source (default: fail-closed)")
+    args = p.parse_args()
+    rng = random.Random(20260425)
+    sources = [args.source] if args.source else COLLECTOR_ORDER
+
+    total = 0
+    failed = 0
+    by_status = {}
+    empty_sources = []
+    for src in sources:
+        samples = collect_samples(src, args.num_samples, rng)
+        if not samples:
+            empty_sources.append(src)
+            continue
+        for source, rec in samples:
+            ok, status = verify_one(source, rec)
+            total += 1
+            by_status[status] = by_status.get(status, 0) + 1
+            if not ok:
+                failed += 1
+
+    print(json.dumps(
+        {"total": total, "failed": failed, "by_status": by_status, "empty_sources": empty_sources},
+        ensure_ascii=False, indent=2,
+    ))
+    if failed > 0:
+        print(f"[verify] FAILED: {failed}/{total} samples failed", file=sys.stderr)
+        return 1
+    if empty_sources and not args.allow_empty:
+        print(f"[verify] FAILED: empty sources {empty_sources} (--allow-empty to bypass)", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/midtrain_vl_50gb/tools/warmup_dm0_vlonly.py
+++ b/midtrain_vl_50gb/tools/warmup_dm0_vlonly.py
@@ -1,0 +1,160 @@
+# DM0 mid-train warmup template (100 steps).
+#
+# Note: DM0 is a dual-expert model and its forward pass requires `actions`
+# tensor (`dm0_arch.py` line ~426). VL-only data does not carry actions, so
+# this script alone will fail at model.forward — that is expected per paper
+# §3.2 design. To run a real warmup, mix this 50GB VL data with a robot source
+# (e.g. `libero_goal+libero_object+libero_spatial`) which provides the action
+# schema. See `docs/06_warmup_findings.md` for details.
+#
+# Usage: torchrun --nproc_per_node=8 warmup_dm0_vlonly.py
+import argparse
+import os
+from dataclasses import dataclass, field
+from datetime import datetime
+
+# Register 50GB data_source before importing dexbotic.data.data_source
+os.environ.setdefault(
+    "DEXBOTIC_DATA_PATH",
+    os.path.join(os.environ.get("DM0_VL_ROOT", "data/dm0_vl_midtrain_50gb"), "data_source"),
+)
+
+from dexbotic.data.dataset.transform.action import (
+    ActionNorm,
+    AddTrajectory,
+    DeltaAction,
+    PadAction,
+    PadState,
+)
+from dexbotic.data.dataset.transform.common import Pipeline, ToDict, ToList, ToNumpy
+from dexbotic.data.dataset.transform.multimodal import LoadMultiModal
+from dexbotic.exp.dm0_exp import DM0Exp as _DM0Exp
+from dexbotic.exp.dm0_exp import (
+    DM0ActionConfig as _DM0ActionConfig,
+    DM0ComputeNormActionConfig as _DM0ComputeNormActionConfig,
+    DM0DataConfig as _DM0DataConfig,
+    DM0ModelConfig as _DM0ModelConfig,
+    DM0OptimizerConfig as _DM0OptimizerConfig,
+    DM0TokenizerConfig as _DM0TokenizerConfig,
+    DM0TrainerConfig as _DM0TrainerConfig,
+)
+from dexbotic.model.dm0.dm0_arch import DM0ForCausalLM
+
+
+@dataclass
+class WarmupOptimizerConfig(_DM0OptimizerConfig):
+    base_lr: float = field(default=1e-5)
+    adam_beta2: float = field(default=0.95)
+    warmup_steps: int = field(default=10)
+    weight_decay: float = field(default=1e-10)
+
+
+@dataclass
+class WarmupTrainerConfig(_DM0TrainerConfig):
+    wandb_project: str = field(default="dm0_midtrain_vl_warmup")
+    bf16: bool = field(default=True)
+    num_train_steps: int = field(default=100)
+    save_steps: int = field(default=100)
+    save_total_limit: int = field(default=1)
+    per_device_train_batch_size: int = field(default=1)
+    gradient_checkpointing: bool = field(default=True)
+    gradient_accumulation_steps: int = field(default=1)
+    output_dir: str = field(
+        default=f"./user_checkpoints/dm0vlmid_warmup/{datetime.now().strftime('%m%d_%H%M')}"
+    )
+    lr_scheduler_type: str = field(default="constant")
+    logging_steps: int = field(default=1)
+    dataloader_num_workers: int = field(default=4)
+    report_to: str = field(default="none")
+
+
+class WarmupNormConfig(_DM0ComputeNormActionConfig):
+    def build_action_process_func(self) -> Pipeline:
+        return Pipeline([
+            ToDict(), ToNumpy(),
+            PadState(ndim=32, axis=-1),
+            PadAction(ndim=32, axis=-1),
+            AddTrajectory(trajectory_length=50, flatten=False, padding_mode="last"),
+            DeltaAction(enable=True),
+            ToList(),
+        ])
+
+
+@dataclass
+class WarmupActionConfig(_DM0ActionConfig):
+    statistic_mapping: str = field(default=None)
+    trajectory_length: int = field(default=50)
+
+    def build_action_process_func(self) -> Pipeline:
+        statistic_mapping = None
+        if self.statistic_mapping:
+            try:
+                statistic_mapping = self._read_norm_stats(self.statistic_mapping)
+            except Exception:
+                statistic_mapping = None
+        steps = [
+            ToDict(), ToNumpy(),
+            PadState(ndim=32, axis=-1),
+            PadAction(ndim=32, axis=-1),
+            AddTrajectory(trajectory_length=50, flatten=False, padding_mode="last"),
+            DeltaAction(enable=True),
+        ]
+        if statistic_mapping:
+            steps.append(ActionNorm(statistic_mapping=statistic_mapping))
+        steps.append(LoadMultiModal(return_masks=True))
+        steps.append(ToList())
+        return Pipeline(steps)
+
+
+@dataclass
+class WarmupDataConfig(_DM0DataConfig):
+    dataset_name: str = field(default=(
+        "dm0vlmid_cambrian737k+dm0vlmid_cambrian10m_filtered+"
+        "dm0vlmid_llava_onevision+dm0vlmid_self_collected_proxy"
+    ))
+    num_images: int = field(default=1)
+    aug_policy: list = field(default_factory=lambda: ["dm0"])
+    data_keys: list = field(default_factory=lambda: ["input_ids", "labels", "image"])
+    auto_norm: bool = field(default=False)
+    action_config: WarmupActionConfig = field(default_factory=WarmupActionConfig)
+
+
+@dataclass
+class WarmupModelConfig(_DM0ModelConfig):
+    model_name_or_path: str = field(
+        default=os.environ.get("DM0_BASE_CKPT", "./checkpoints/DM0-base")
+    )
+
+    def build_model(self) -> DM0ForCausalLM:
+        return DM0ForCausalLM.from_pretrained(self.model_name_or_path)
+
+
+@dataclass
+class WarmupTokenizerConfig(_DM0TokenizerConfig):
+    use_fast_tokenizer: bool = field(default=False)
+
+
+@dataclass
+class WarmupExp(_DM0Exp):
+    model_config: WarmupModelConfig = field(default_factory=WarmupModelConfig)
+    optimizer_config: WarmupOptimizerConfig = field(default_factory=WarmupOptimizerConfig)
+    trainer_config: WarmupTrainerConfig = field(default_factory=WarmupTrainerConfig)
+    data_config: WarmupDataConfig = field(default_factory=WarmupDataConfig)
+    tokenizer_config: WarmupTokenizerConfig = field(default_factory=WarmupTokenizerConfig)
+
+    def _auto_compute_norm_stats(self) -> None:
+        if self.local_rank == 0:
+            print("[warmup] skip auto_compute_norm_stats (VL-only data)", flush=True)
+
+
+def parse_args():
+    p = argparse.ArgumentParser()
+    p.add_argument("--task", type=str, default="train", choices=["train"])
+    a, _ = p.parse_known_args()
+    return a
+
+
+if __name__ == "__main__":
+    parse_args()
+    import dexbotic.data.data_source  # noqa: F401
+    WarmupExp().train()


### PR DESCRIPTION
## Summary

Reproducible pipeline assembling a 50GB Vision-Language corpus that follows DM0 paper §3.2 Mid-Training. Drops directly into the dexbotic `DexDataset` / `DataCollatorForSupervisedDataset` flow via a new `DM0_VL_ROOT`-driven register file.

- ~515k samples / 50.55 GB images / 4 sources / 35 jsonl shards
- New tooling lives under `midtrain_vl_50gb/` (separate from existing benchmarks/playground)
- Adds `dexbotic/data/data_source/dm0vl_midtrain_official.py` (upstream-style register, env-driven path)
- All paths configurable; **no proxy IPs / personal home dirs / venv paths committed**

## Sources (Paper §3.2 VL split)

| Source | HF repo | Target | Notes |
|--------|---------|--------|-------|
| `dm0vlmid_cambrian737k` | `LanguageBind/Cambrian737k` | 12 GB | full COCO download with shuffle |
| `dm0vlmid_cambrian10m_filtered` | `nyu-visionx/Cambrian-10M` | 20 GB → ~10 GB | source-limited by COCO pool dedupe vs c737k |
| `dm0vlmid_llava_onevision` | `lmms-lab/LLaVA-OneVision-Data` | 22 GB | 30 subsets, dynamic per-subset quota |
| `dm0vlmid_self_collected_proxy` | `zonghanHZH/UGround-V1-8k` + `Phineas476/EmbSpatial-Bench` + `naver-clova-ix/synthdog-en` + `naver-clova-ix/cord-v2` | 8 GB | covers GUI grounding / embodied-spatial QA / OCR / receipt OCR |

## Key engineering pieces

- `DurableEpisodeWriter` — progress.json mirrors only flushed-to-disk state; crash mid-batch loses pending in-memory rows but never corrupts written jsonl.
- `stream_jsonl` — Range-resumable JSONL streaming with proxy-aware reconnect (handles SSL EOF on long downloads through corporate proxies).
- `reconcile_progress.py` — rebuilds `subset_bytes_record` from on-disk jsonl + image stat; canonicalises `synthdog → synthdog_en` and `cord → cord_v2`.
- `subset_coverage_check.py --strict` — paper-aligned strict gate (e.g. `self_collected_proxy.embspatial >= 50 MB`); catches the failure mode where total bytes hit target but a critical subset is empty.
- `prepare.py` — single entrypoint, auto-discovers collectors, fail-closed.
- All shell-out scripts use `set -euo pipefail` + `PIPESTATUS[0]`.

## Validation (8 × NVIDIA H200, dexbotic main)

- `verify_dataset.py --num-samples 2048`: **8192/8192 PIL.open OK**, 0 failed
- `subset_coverage_check.py --strict`: all 4 sources OK (incl. `embspatial 267.8 MB`)
- `test_dataloader.py`: `dataset_len = 515,572`, batch keys `{input_ids, labels, attention_mask, images}` complete
- Throughput **69.7 samples/s** (bs=32 nw=16, dummy processors) — exceeds the smoke-bench threshold
- DM0-base load + 8-rank deepspeed init OK (each GPU ~6.1 GB resident)

## Test plan

- [x] `pytest midtrain_vl_50gb/tests/ -v` — DurableEpisodeWriter resume/dedup, reconcile alias, coverage thresholds
- [x] `python midtrain_vl_50gb/tools/prepare.py --dry-run`
- [x] `python midtrain_vl_50gb/tools/test_dataloader.py`
- [x] `python midtrain_vl_50gb/tools/verify_dataset.py --num-samples 2048`
- [x] `python midtrain_vl_50gb/tools/subset_coverage_check.py --strict`

See `midtrain_vl_50gb/docs/07_verification_steps.md` for the full step-by-step reproduction checklist.

## Limitations

1. `cambrian10m_filtered` settles at 9-11 GB (COCO pool dedup'd against c737k). Total is `~50 GB` not strictly per the 12/20/10/8 paper recipe; documented as `paper-aligned, source-limited 50GB VL mid-train corpus`.
2. `self_collected_proxy.embspatial` uses the open `Phineas476/EmbSpatial-Bench` (3640 base64-encoded JPEGs) as a proxy for the paper's "caption-reannotated embodied data", which has no public release.
3. DM0 model forward needs an `actions` tensor — VL-only data alone is not trainable, by design (paper §3.2). Use mixed (e.g. `dm0vlmid_* + libero_goal+...`) for actual mid-train. See `midtrain_vl_50gb/docs/06_warmup_findings.md`.

## Files added

- `dexbotic/data/data_source/dm0vl_midtrain_official.py` (1)
- `midtrain_vl_50gb/README.md` (1)
- `midtrain_vl_50gb/tools/*.py` (10) — recipe, _collector_base, disk_guard, prepare, reconcile_progress, precompute_index_cache, subset_coverage_check, test_dataloader, verify_dataset, warmup_dm0_vlonly
- `midtrain_vl_50gb/tools/collectors/*.py` (5) — `__init__`, cambrian737k, cambrian10m_filtered, llava_onevision, self_collected_proxy
- `midtrain_vl_50gb/tests/test_*.py` (3) — collector_base, reconcile, subset_coverage
- `midtrain_vl_50gb/docs/*.md` (3) — final summary, warmup findings, verification steps
- `.gitignore` whitelist for the new register file

🤖 Generated with [Claude Code](https://claude.com/claude-code)