### PR TITLE
Fix: Inconsistent video path naming between data_source configs and conversion scripts(#84)

### DIFF
--- a/hardware/docs/so101_inference_example.md
+++ b/hardware/docs/so101_inference_example.md
@@ -59,9 +59,9 @@ The output structure should look like this:
 
 ```text
 so101_dexdata/
-├── dexdata_jsonl/
+├── jsonl/
 │   └── push_button/episode_00000.jsonl
-└── videos/
+└── video/
     └── push_button/episode_00000_front.mp4
 ```
 
@@ -80,8 +80,8 @@ from dexbotic.data.data_source.register import register_dataset
 
 SO101_DATASET = {
     "push_button": {
-        "data_path_prefix": "./dexbotic/so101_dexdata/videos/push_button",
-        "annotations": "./so101_dexdata/dexdata_jsonl/push_button",
+        "data_path_prefix": "./dexbotic/so101_dexdata/video/push_button",
+        "annotations": "./so101_dexdata/jsonl/push_button",
         "frequency": 1,
     },
 }

--- a/hardware/docs/xlerobot_inference_example.md
+++ b/hardware/docs/xlerobot_inference_example.md
@@ -96,7 +96,7 @@ xlerobot_dexdata/
 │       ├── episode_00000.jsonl
 │       ├── episode_00001.jsonl
 │       └── ...
-└── videos/
+└── video/
     └── <task_name>/
         ├── episode_00000_head.mp4
         ├── episode_00000_wrist_left.mp4
@@ -124,7 +124,7 @@ from dexbotic.data.data_source.register import register_dataset
 
 XLEROBOT_DATASET = {
     "<task_name>": {
-        "data_path_prefix": "/path/to/dexdata/videos",
+        "data_path_prefix": "/path/to/dexdata/video",
         "annotations": "/path/to/dexdata/jsonl/<task_name>",
         "frequency": 1,
     },

--- a/hardware/so101/convert_so101_to_dexdata.py
+++ b/hardware/so101/convert_so101_to_dexdata.py
@@ -173,7 +173,7 @@ def main(lerobot_dir, output_dir):
                 camera_folders = []
 
             output_jsonl_dir = os.path.join(output_dir, "jsonl", task_name)
-            output_video_dir = os.path.join(output_dir, "videos", task_name)
+            output_video_dir = os.path.join(output_dir, "video", task_name)
             os.makedirs(output_jsonl_dir, exist_ok=True)
             os.makedirs(output_video_dir, exist_ok=True)
 

--- a/hardware/xlerobot/convert_xlerobot_to_dexdata.py
+++ b/hardware/xlerobot/convert_xlerobot_to_dexdata.py
@@ -166,7 +166,7 @@ def main(lerobot_dir: str, output_dir: str) -> None:
 
     # 2. Prepare Output Paths
     output_jsonl_dir = os.path.join(output_dir, "jsonl", task_name)
-    output_video_dir = os.path.join(output_dir, "videos", task_name)
+    output_video_dir = os.path.join(output_dir, "video", task_name)
     os.makedirs(output_jsonl_dir, exist_ok=True)
     os.makedirs(output_video_dir, exist_ok=True)
 

--- a/script/convert_data/convert_lerobot_to_dexdata.py
+++ b/script/convert_data/convert_lerobot_to_dexdata.py
@@ -210,7 +210,7 @@ def main(lerobot_dir, output_dir):
         if not os.path.isdir(task_root):
             continue 
         output_jsonl_dir = os.path.join(output_dir, "jsonl", task_name)
-        output_video_dir = os.path.join(output_dir, "videos", task_name)
+        output_video_dir = os.path.join(output_dir, "video", task_name)
         os.makedirs(output_jsonl_dir, exist_ok=True)
         os.makedirs(output_video_dir, exist_ok=True)
         task_list = get_task_list(task_root)

--- a/script/convert_data/convert_rlds_to_dexdata.py
+++ b/script/convert_data/convert_rlds_to_dexdata.py
@@ -288,8 +288,8 @@ def load_rlds_dataset(
         dataset_name (str): Dataset name, e.g., 'libero_10_no_noops'
         split (str): Data split, options include 'train', 'validation', 'test', default is 'train'
         data_dir (str): Data storage directory, uses default if None
-        output_dir (str): Root directory for output files (videos and JSONs), default is './output'
-        frame_rate (int): Frame rate for output videos, default is 10
+        output_dir (str): Root directory for output files (video and JSONL), default is './output'
+        frame_rate (int): Frame rate for output video, default is 10
         verbose (bool): Enable verbose output, default is False
     """
     if dataset_name in DATASET_CONFIG:
@@ -343,8 +343,8 @@ def load_rlds_dataset(
 
     dataset = dataset.traj_map(restructure, num_parallel_calls=10)
 
-    video_output_path = os.path.join(output_dir, "videos")
-    json_output_path = os.path.join(output_dir, "jsons")
+    video_output_path = os.path.join(output_dir, "video")
+    json_output_path = os.path.join(output_dir, "jsonl")
     os.makedirs(video_output_path, exist_ok=True)
     os.makedirs(json_output_path, exist_ok=True)
     # Process episodes and convert to DexData format
@@ -382,10 +382,10 @@ def load_rlds_dataset(
             for writer in video_writers.values():
                 writer.close()
 
-            # Save JSON file
-            json_save_relative_path = os.path.join(dataset_name, f"episode{str(episode_index)}.jsonl")
-            json_full_path = os.path.join(json_output_path, json_save_relative_path)
-            save_json_file(jsons_tmp, json_full_path)
+            # Save JSONL file
+            jsonl_save_relative_path = os.path.join(dataset_name, f"episode{str(episode_index)}.jsonl")
+            jsonl_full_path = os.path.join(json_output_path, jsonl_save_relative_path)
+            save_json_file(jsons_tmp, jsonl_full_path)
 
             processed_episodes += 1
             if verbose:
@@ -401,7 +401,7 @@ def load_rlds_dataset(
         print(f"\n=== Episode Processing Complete ===")
         print(f"Successfully processed {processed_episodes} episodes")
         print(f"Video files saved to: {video_output_path}")
-        print(f"JSON files saved to: {json_output_path}")
+        print(f"JSONL files saved to: {json_output_path}")
     else:
         print(f"\nProcessing complete! Successfully processed {processed_episodes} episodes.")
 
@@ -415,7 +415,7 @@ def parse_arguments():
         argparse.Namespace: Parsed command line arguments
     """
     parser = argparse.ArgumentParser(
-        description="Convert RLDS datasets to DexData format with video and JSON outputs.",
+        description="Convert RLDS datasets to DexData format with video and JSONL outputs.",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
 
@@ -446,14 +446,14 @@ def parse_arguments():
         "--output_dir",
         type=str,
         default="./output",
-        help="Root directory for output files (videos and JSONs)"
+        help="Root directory for output files (video and JSONL)"
     )
 
     parser.add_argument(
         "--frame_rate",
         type=int,
         default=10,
-        help="Frame rate for output videos"
+        help="Frame rate for output video"
     )
 
     parser.add_argument(


### PR DESCRIPTION
## 📝 PR Description

### Purpose
Fix inconsistent data_path_prefix directory naming between dexbotic/data/data_source/*_official.py files and conversion scripts. The configs used video (singular) while scripts output to videos/
  (plural), causing path mismatch during training.

### Change Summary
  - Modified `convert_lerobot_to_dexdata.py`: output video files under video/ instead of videos/
  - Modified `convert_rlds_to_dexdata.py`: output video files under video/ instead of videos/
  - Modified `convert_xlerobot_to_dexdata.py`: output video files under video/ instead of videos/
  - Updated docs (so101_inference_example.md, xlerobot_inference_example.md): aligned with video/ convention

### Benchmark Evidence
N/A (path configuration change only)

### Reproduce Command
(Provide a minimal command to reproduce the result or behavior)
<insert command here>

### Dependencies
None

### Environment
(CPU/GPU/OS/Driver as needed)
 
## ✔️ Review Checklist (must all be checked)
- [✔️ ] No breaking changes to core interfaces (VLA API / Dexdata)
- [✔️ ] No redundant implementation (checked existing modules first)
- [✔️ ] Code follows existing design [link](https://dexbotic.com/docs/3.%20Architecture.html#overall-framework-diagram)
- [X ] Local validation completed with commands + expected output
- [X ] Benchmark evaluation completed and attached
- [✔️ ] No regressions observed
- [✔️ ] No new dependencies or all new dependencies listed
- [✔️ ] Merges cleanly on current main and builds successfully

Closes #84