### PR TITLE
docs: fix README grammar and typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 ## Introduction
 
-**Dexbotic** is a VLA (Vision-Language-Action) development toolbox built on the PyTorch framework, designed to provide a unified and efficient solution for embodied intelligence research. It comes with built-in environment configurations for various mainstream VLA models, allowing users to reproduce, fine-tune, and inference cutting-edge VLA algorithms with simple setup.
+**Dexbotic** is a VLA (Vision-Language-Action) development toolbox built on the PyTorch framework, designed to provide a unified and efficient solution for embodied intelligence research. It comes with built-in environment configurations for various mainstream VLA models, allowing users to reproduce, fine-tune, and run inference on cutting-edge VLA algorithms with a simple setup.
 
 - **Ready-to-Use VLA Framework**: Centered around VLA models, integrating embodied manipulation and navigation capabilities, supporting multiple cutting-edge algorithms.
 - **High-Performance Pre-trained Foundation Models**: For mainstream VLA algorithms such as π0 and CogACT, Dexbotic provides multiple optimized pre-trained models.
@@ -160,7 +160,7 @@ A: For detailed installation instructions and troubleshooting, please refer to t
 </details>
 
 <details close>
-<summary>Q: Coverting RLDS/LeRobot to Dexdata</summary>
+<summary>Q: Converting RLDS/LeRobot to Dexdata</summary>
 
 A: We provide a general data conversion guide in [data conversion](docs/Data.md#2-data-conversion). An example of Lerobot data conversion can be found in [convert_lerobot_to_dexdata](script/convert_data/convert_lerobot_to_dexdata.py), and an example for RLDS data conversion is available in [convert_rlds_to_dexdata](script/convert_data/convert_rlds_to_dexdata.py).
 </details>


### PR DESCRIPTION

### Purpose
Fix two small documentation issues in the project README: a grammatical wording that made "inference" read like a verb, and a typo in the FAQ heading.

### Change Summary
- Modified README.md:
  - Reworded: "reproduce, fine-tune, and inference..." → "reproduce, fine-tune, and run inference on..."
  - Fixed typo: "Coverting RLDS/LeRobot to Dexdata" → "Converting RLDS/LeRobot to Dexdata"

### Benchmark Evidence
- Not applicable (documentation-only change).

### Dependencies
None

### Environment
Not applicable (docs change)

## ✔️ Review Checklist (must all be checked)
- [x] No breaking changes to core interfaces (VLA API / Dexdata) — docs only.
- [x] No redundant implementation (checked existing modules first) — no code added.
- [x] Code follows existing design [link](https://dexbotic.com/docs/3.%20Architecture.html#overall-framework-diagram) — not applicable; docs-only change.
- [x] Local validation completed with commands + expected output — `git show` confirms the edits.
- [x] Benchmark evaluation completed and attached — N/A (docs-only).
- [x] No regressions observed — docs-only.
- [x] No new dependencies or all new dependencies listed — None.
- [x] Merges cleanly on current main and builds successfully — should merge cleanly; no build impact.