### PR TITLE
RFE: replace print() with logging in core runtime modules

### DIFF
--- a/dexbotic/client.py
+++ b/dexbotic/client.py
@@ -1,9 +1,12 @@
 from collections import deque
+import logging
 import requests
 import math
 
 import numpy as np
 import cv2
+
+logger = logging.getLogger(__name__)
 
 
 class DexClient:
@@ -86,4 +89,4 @@ if __name__ == "__main__":
         action = client.act(
             observation,
             "What action should the robot take to put both moka pots on the stove?")
-        print("Action taken:", action)
+        logger.info("Action taken: %s", action)

--- a/dexbotic/rl/_embodied_cli.py
+++ b/dexbotic/rl/_embodied_cli.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 
 import torch.multiprocessing as mp
 from omegaconf import OmegaConf
+
+logger = logging.getLogger(__name__)
 
 from rlinf.config import validate_cfg
 from rlinf.runners.embodied_runner import EmbodiedRunner
@@ -25,12 +28,10 @@ def run_embodied_rl(cfg) -> None:
 
     register_all()
 
-    print(
-        "[Dexbotic RL] Launching from Dexbotic entrypoint with RLinf as backend."
-    )
+    logger.info("[Dexbotic RL] Launching from Dexbotic entrypoint with RLinf as backend.")
 
     cfg = validate_cfg(cfg)
-    print(json.dumps(OmegaConf.to_container(cfg, resolve=True), indent=2))
+    logger.info(json.dumps(OmegaConf.to_container(cfg, resolve=True), indent=2))
 
     cluster = Cluster(
         cluster_cfg=cfg.cluster, distributed_log_dir=cfg.runner.per_worker_log_path

--- a/playground/example_navila_exp.py
+++ b/playground/example_navila_exp.py
@@ -6,10 +6,13 @@ python playground/example_navila_exp.py --task inference_single --image_path tes
 
 """
 import argparse
+import logging
 from collections import deque
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Optional
+
+logger = logging.getLogger(__name__)
 
 from dexbotic.data.dataset.transform.common import Pipeline, ToDict, ToList, ToNumpy
 from dexbotic.data.dataset.transform.multimodal import LoadMultiModal
@@ -139,7 +142,7 @@ class Exp(NaVILAExp):
             with open(image_path, "rb") as f:
                 image_bytes = f.read()
         except FileNotFoundError:
-            print(f"Error: image file not found {image_path}")
+            logger.error("Error: image file not found %s", image_path)
             return None
 
         images_list = self.inference_config._prepare_images(image_bytes)
@@ -150,7 +153,7 @@ class Exp(NaVILAExp):
             text=prompt,
             images=images_list,
         )
-        print(f"Inference result: {result}")
+        logger.info("Inference result: %s", result)
         return result
 
 


### PR DESCRIPTION
## 📝 PR Description

### Purpose
Standardize logging in core runtime modules by replacing direct `print()` calls with the Python `logging` module. This improves consistency, supports _CI/service deployment, and makes log handling more manageable.

### Change Summary
- client.py
  - Added `import logging`
  - Added `logger = logging.getLogger(__name__)`
  - Replaced `print("Action taken:", action)` with `logger.info("Action taken: %s", action)`
- _embodied_cli.py
  - Added `import logging`
  - Added `logger = logging.getLogger(__name__)`
  - Replaced startup/config prints with `logger.info(...)`
- example_navila_exp.py
  - Added `import logging`
  - Added `logger = logging.getLogger(__name__)`
  - Replaced file-not-found print with `logger.error(...)`
  - Replaced inference result print with `logger.info(...)`

### Benchmark Evidence
- Not applicable for this logging refactor.

#### Dependencies
None

#### Environment
- Python 3
- Branch: `fix/logging-print-replacement`

## ✔️ Review Checklist
- [x] No breaking changes to core interfaces (VLA API / Dexdata)
- [x] No redundant implementation
- [x] Code follows existing design
- [x] Local validation completed with commands + expected output
- [x] Benchmark evaluation not applicable
- [x] No regressions observed
- [x] No new dependencies
- [x] Merges cleanly on current `main`